### PR TITLE
feat(prompt): made rules optional, added a no-rules system prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 ### Changed
 
 - changed `BuildSystemPrompt` to fall back to a general best-practices system prompt when no rules are loaded; the previous template embedded an empty `Rules to enforce` block plus the instruction `Do NOT comment on style preferences not covered by the rules`, which made the LLM correctly produce zero comments on every PR when `CODE_GURU_RULES_PATH` was unset or no rules matched the file languages — the no-rules path now asks the model to review for bugs, security issues, performance problems, and clear correctness violations without referencing a non-existent rule set
+- changed both system prompt templates to include `"verdict": "approve"` in the no-issues example so the LLM does not omit the field on clean reviews; without this, `ParseReviewResponse` defaulted to `comment` and downstream automation could never reach a clean `approve` verdict
 
 ## [1.3.0] - 2026-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- changed `BuildSystemPrompt` to fall back to a general best-practices system prompt when no rules are loaded; the previous template embedded an empty `Rules to enforce` block plus the instruction `Do NOT comment on style preferences not covered by the rules`, which made the LLM correctly produce zero comments on every PR when `CODE_GURU_RULES_PATH` was unset or no rules matched the file languages — the no-rules path now asks the model to review for bugs, security issues, performance problems, and clear correctness violations without referencing a non-existent rule set
+
 ## [1.3.0] - 2026-04-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 - changed `BuildSystemPrompt` to fall back to a general best-practices system prompt when no rules are loaded; the previous template embedded an empty `Rules to enforce` block plus the instruction `Do NOT comment on style preferences not covered by the rules`, which made the LLM correctly produce zero comments on every PR when `CODE_GURU_RULES_PATH` was unset or no rules matched the file languages — the no-rules path now asks the model to review for bugs, security issues, performance problems, and clear correctness violations without referencing a non-existent rule set
 - changed both system prompt templates to include `"verdict": "approve"` in the no-issues example so the LLM does not omit the field on clean reviews; without this, `ParseReviewResponse` defaulted to `comment` and downstream automation could never reach a clean `approve` verdict
+- changed the `Dockerfile` `SHELL` directive from `["/bin/bash", "-c"]` to `["/bin/bash", "-eo", "pipefail", "-c"]` so `pipefail` is enforced at the shell level for every `RUN` (the inline `set -euxo pipefail` becomes redundant defense in depth) — fixes hadolint `DL4006` triggered by the `claude --version | tee /etc/claude-version` pipe added in `1.4.0`
 
 ## [1.3.0] - 2026-04-28
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,12 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
 # is left in the reference for human readability.
 FROM debian:12-slim@sha256:f9c6a2fd2ddbc23e336b6257a5245e31f996953ef06cd13a59fa0a1df2d5c252
 
-# Use bash for RUN steps so `set -o pipefail` works (debian's /bin/sh is
-# dash, which has no pipefail). Bash ships in the base image already; this
-# directive only changes the shell Docker invokes for subsequent RUNs.
-SHELL ["/bin/bash", "-c"]
+# Use bash for RUN steps with `pipefail` enabled at the shell level so any
+# pipe (e.g. `claude --version | tee /etc/claude-version` below) propagates
+# failures from the upstream command. Setting `-o pipefail` on SHELL itself
+# also satisfies hadolint DL4006 — the inline `set -euxo pipefail` further
+# down is now redundant defense-in-depth.
+SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
 
 # Install the Claude Code native binary to a system path so it survives the
 # Kubernetes emptyDir mount on /home/nonroot/.claude (which masks anything the

--- a/internal/support/prompt_builder.go
+++ b/internal/support/prompt_builder.go
@@ -7,7 +7,7 @@ import (
 	"github.com/rios0rios0/codeguru/internal/domain/entities"
 )
 
-const systemPromptTemplate = `You are a senior code reviewer. Review the following code changes for issues, improvements, and adherence to the team's coding standards.
+const systemPromptTemplateWithRules = `You are a senior code reviewer. Review the following code changes for issues, improvements, and adherence to the team's coding standards.
 
 Rules to enforce:
 ---
@@ -57,8 +57,60 @@ Guidelines:
 - Keep comments concise and actionable
 - "suggestion" is optional; include it when proposing replacement code`
 
-// BuildSystemPrompt assembles the system prompt from the given rules.
+const systemPromptTemplateNoRules = `You are a senior code reviewer. Review the following code changes for bugs, security issues, performance problems, and clear correctness violations using widely-accepted software engineering best practices.
+
+CRITICAL: Respond with ONLY a valid JSON object. Do NOT wrap it in markdown code blocks or add any text outside the JSON.
+
+Response schema:
+{
+  "verdict": "approve",
+  "summary": "Brief overall assessment of the PR",
+  "comments": [
+    {
+      "file": "path/to/file.go",
+      "line": 42,
+      "end_line": 45,
+      "severity": "error",
+      "body": "Explanation of the issue and suggested fix",
+      "suggestion": "optional replacement code"
+    }
+  ]
+}
+
+Verdict rules:
+- "approve": no blocking issues found, the PR is safe to merge as-is
+- "request_changes": there are error-level issues that must be fixed before merging
+- "comment": there are warnings or informational observations but nothing blocking
+
+Line number rules:
+- "line" MUST be a line number in the NEW version of the file (right side of the diff)
+- Use the @@ hunk headers to compute absolute line numbers (e.g., @@ -10,5 +12,7 @@ means new file starts at line 12)
+- Only comment on added (+) or modified lines that appear in the diff
+- "end_line" is optional; use it only for multi-line issues
+- Do NOT comment on lines outside the diff
+
+Severity levels:
+- "error": bugs, security issues, or definite correctness problems
+- "warning": potential improvements, risky patterns, or non-blocking concerns
+- "info": suggestions or minor observations
+
+Guidelines:
+- Comment on actual bugs, security flaws, performance issues, and clear correctness problems
+- Avoid style nitpicks unless they significantly hurt readability or maintainability
+- If there are no issues, return {"summary": "No issues found.", "comments": []}
+- Keep comments concise and actionable
+- "suggestion" is optional; include it when proposing replacement code`
+
+// BuildSystemPrompt assembles the system prompt from the given rules. When
+// rules is empty, a different template is used that asks for a general
+// best-practices code review (the rules-based template instructs the model
+// not to comment outside the rules, which produces zero comments when the
+// rules block is empty).
 func BuildSystemPrompt(rules []entities.Rule) string {
+	if len(rules) == 0 {
+		return systemPromptTemplateNoRules
+	}
+
 	var rulesContent strings.Builder
 	for _, rule := range rules {
 		fmt.Fprintf(&rulesContent, "### %s\n\n", rule.Name)
@@ -66,7 +118,7 @@ func BuildSystemPrompt(rules []entities.Rule) string {
 		rulesContent.WriteString("\n\n")
 	}
 
-	return fmt.Sprintf(systemPromptTemplate, rulesContent.String())
+	return fmt.Sprintf(systemPromptTemplateWithRules, rulesContent.String())
 }
 
 // BuildUserPrompt assembles the user prompt from PR metadata and file diffs.

--- a/internal/support/prompt_builder.go
+++ b/internal/support/prompt_builder.go
@@ -52,7 +52,7 @@ Severity levels:
 Guidelines:
 - Only comment on actual issues or clear improvements
 - Do NOT comment on style preferences not covered by the rules
-- If there are no issues, return {"summary": "No issues found.", "comments": []}
+- If there are no issues, return {"verdict": "approve", "summary": "No issues found.", "comments": []}
 - Reference the specific rule being violated when applicable
 - Keep comments concise and actionable
 - "suggestion" is optional; include it when proposing replacement code`
@@ -97,7 +97,7 @@ Severity levels:
 Guidelines:
 - Comment on actual bugs, security flaws, performance issues, and clear correctness problems
 - Avoid style nitpicks unless they significantly hurt readability or maintainability
-- If there are no issues, return {"summary": "No issues found.", "comments": []}
+- If there are no issues, return {"verdict": "approve", "summary": "No issues found.", "comments": []}
 - Keep comments concise and actionable
 - "suggestion" is optional; include it when proposing replacement code`
 

--- a/internal/support/prompt_builder_test.go
+++ b/internal/support/prompt_builder_test.go
@@ -79,6 +79,24 @@ func TestBuildSystemPrompt(t *testing.T) {
 		assert.Contains(t, result, "Do NOT comment on style preferences not covered by the rules")
 	})
 
+	t.Run("should instruct the model to set an explicit approve verdict on a clean review (both templates)", func(t *testing.T) {
+		// given
+		rulesProvided := []entities.Rule{
+			entitybuilders.NewRuleBuilder().WithName("security").WithContent("never expose secrets").BuildRule(),
+		}
+		var rulesEmpty []entities.Rule
+
+		// when
+		withRules := support.BuildSystemPrompt(rulesProvided)
+		noRules := support.BuildSystemPrompt(rulesEmpty)
+
+		// then: both templates must include `"verdict": "approve"` in the
+		// no-issues example, otherwise ParseReviewResponse would fall back to
+		// `comment` and downstream automation can never reach a clean approve.
+		assert.Contains(t, withRules, `"verdict": "approve", "summary": "No issues found.", "comments": []`)
+		assert.Contains(t, noRules, `"verdict": "approve", "summary": "No issues found.", "comments": []`)
+	})
+
 	t.Run("should not include best-practices wording when rules are provided", func(t *testing.T) {
 		// given
 		rules := []entities.Rule{

--- a/internal/support/prompt_builder_test.go
+++ b/internal/support/prompt_builder_test.go
@@ -47,16 +47,50 @@ func TestBuildSystemPrompt(t *testing.T) {
 		assert.Contains(t, result, "JSON")
 	})
 
-	t.Run("should handle empty rules", func(t *testing.T) {
+	t.Run("should fall back to a no-rules template when no rules are provided", func(t *testing.T) {
 		// given
 		var rules []entities.Rule
 
 		// when
 		result := support.BuildSystemPrompt(rules)
 
-		// then
+		// then: the no-rules template asks for a general best-practices review
+		// and (critically) does NOT instruct the model to skip anything outside
+		// the rule set — the with-rules template has that constraint and would
+		// produce zero comments against an empty rules block.
 		assert.NotEmpty(t, result)
 		assert.Contains(t, result, "senior code reviewer")
+		assert.Contains(t, result, "best practices")
+		assert.NotContains(t, result, "Rules to enforce")
+		assert.NotContains(t, result, "Do NOT comment on style preferences not covered by the rules")
+	})
+
+	t.Run("should keep the rules-block instruction when rules are provided", func(t *testing.T) {
+		// given
+		rules := []entities.Rule{
+			entitybuilders.NewRuleBuilder().WithName("security").WithContent("never expose secrets").BuildRule(),
+		}
+
+		// when
+		result := support.BuildSystemPrompt(rules)
+
+		// then
+		assert.Contains(t, result, "Rules to enforce")
+		assert.Contains(t, result, "Do NOT comment on style preferences not covered by the rules")
+	})
+
+	t.Run("should not include best-practices wording when rules are provided", func(t *testing.T) {
+		// given
+		rules := []entities.Rule{
+			entitybuilders.NewRuleBuilder().WithName("security").WithContent("never expose secrets").BuildRule(),
+		}
+
+		// when
+		result := support.BuildSystemPrompt(rules)
+
+		// then: the no-rules template wording must not leak into rules-mode
+		// (otherwise the model could be tempted to ignore the rules).
+		assert.NotContains(t, result, "widely-accepted software engineering best practices")
 	})
 }
 


### PR DESCRIPTION
## Summary

`BuildSystemPrompt` always emitted the rules-mode template, even when zero rules were loaded. That template carries the instruction `Do NOT comment on style preferences not covered by the rules` — so with an empty rules block, the LLM had no permission to comment on anything and dutifully returned an empty review. The K8s smoke test on `backend/catalog` showed exactly that: webhook fired, pod processed it, and `loaded 0 rules for languages: []` was the last meaningful log line — no comment posted to the PR.

## What changed

- Added `systemPromptTemplateNoRules` — a separate template that asks for a general best-practices code review (bugs, security, performance, correctness) and **does not** reference a rules block.
- `BuildSystemPrompt` now branches on `len(rules)`: empty → no-rules template, non-empty → existing rules template (unchanged).
- Renamed the existing `systemPromptTemplate` to `systemPromptTemplateWithRules` for symmetry.

## Test plan

- [x] `go test -tags unit ./internal/support/...` — all pass
- [x] `make lint` — 0 issues
- [x] New tests assert the rules-only constraint is absent from the no-rules path and the best-practices wording is absent from the rules-only path
- [ ] Reviewer reads the no-rules template wording for tone/scope appropriateness — happy to tighten if the model produces too-noisy reviews on no-rules deployments

## Impact

Unblocks deployments that don't ship a rules directory (e.g., the K8s shared-toolbox `code-guru` pod, where no `CODE_GURU_RULES_PATH` is wired yet). The next webhook delivery on a no-rules deployment will produce an actual review comment instead of silently bailing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)