### PR TITLE
feat(ci): enabled deliver_docker on default.yaml

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -15,6 +15,7 @@ permissions:
   checks: 'write' # code_check-style_golangci_lint
   security-events: 'write' # security-sast_codeql
   contents: 'write' # delivery-release
+  packages: 'write' # delivery-docker (deliver_docker: true) — push to ghcr.io/rios0rios0/code-guru
 
 jobs:
   default:

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -21,3 +21,9 @@ jobs:
     uses: 'rios0rios0/pipelines/.github/workflows/go-binary.yaml@main'
     with:
       binary_name: 'code-guru'
+      # Build and publish a Docker image to ghcr.io/rios0rios0/code-guru
+      # alongside the binary release. Until this was set, every image bump
+      # required a manual `docker build && docker push` (see the 0.2.0
+      # rollout for the toolbox stack). Opt-in flag added in
+      # rios0rios0/pipelines#383.
+      deliver_docker: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 ### Added
 
 - added `deliver_docker: true` to `.github/workflows/default.yaml` so future tag pushes automatically build and publish the Docker image to `ghcr.io/rios0rios0/code-guru` alongside the binary release; previously every image bump required a manual `docker build && docker push` (see the `0.2.0` rollout for the toolbox stack)
+- added `packages: 'write'` to the workflow `permissions:` block so the `delivery-docker` job can authenticate to GHCR; reusable workflows cannot escalate beyond the caller's grants, so the permission has to be declared at the caller level
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added `deliver_docker: true` to `.github/workflows/default.yaml` so future tag pushes automatically build and publish the Docker image to `ghcr.io/rios0rios0/code-guru` alongside the binary release; previously every image bump required a manual `docker build && docker push` (see the `0.2.0` rollout for the toolbox stack)
+
 ### Changed
 
 - changed `BuildSystemPrompt` to fall back to a general best-practices system prompt when no rules are loaded; the previous template embedded an empty `Rules to enforce` block plus the instruction `Do NOT comment on style preferences not covered by the rules`, which made the LLM correctly produce zero comments on every PR when `CODE_GURU_RULES_PATH` was unset or no rules matched the file languages — the no-rules path now asks the model to review for bugs, security issues, performance problems, and clear correctness violations without referencing a non-existent rule set


### PR DESCRIPTION
## Summary

The shared `go-binary.yaml` workflow gained an opt-in `deliver_docker` input via [rios0rios0/pipelines#383](https://github.com/rios0rios0/pipelines/pull/383) (already merged). Setting it `true` here means every tag push automatically builds and pushes a Docker image to `ghcr.io/rios0rios0/code-guru` with `:X.Y.Z`, `:X.Y`, and `:latest` tags computed from the release version.

Until this flag was set, every image bump required a manual `docker build && docker push` — that's how the `0.2.0` image consumed by the shared-toolbox stack was published.

## What changed

`.github/workflows/default.yaml` — added `deliver_docker: true` under the `with:` block of the `default` job. CHANGELOG entry added under `[Unreleased] > Added`.

## Test plan

- [ ] Reviewer cuts a no-op tag bump (e.g. `1.4.1`) and confirms the next default workflow run produces both the binary release artifacts AND a fresh `ghcr.io/rios0rios0/code-guru:1.4.1` image
- [ ] After confirming, the toolbox stack can bump `image_tag` without a manual rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)