### PR TITLE
feat(webhook): added source-IP allowlist with Cloudflare-aware client IP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,8 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Added
 
-- added `Server.AllowedSourceCIDRs` (env: `CODE_GURU_SERVER_ALLOWED_SOURCE_CIDRS`) — a comma-separated CIDR allowlist enforced on `/webhooks/azuredevops` and `/webhooks/github` before any auth check; the source IP is read from `CF-Connecting-IP`, then `X-Real-IP`, then the leftmost `X-Forwarded-For` entry, then `RemoteAddr` (in that order); empty list means "no allowlist", preserving existing behaviour
-- added `clientIP(*http.Request)` and `sourceIPAllowed(ip, cidrs)` helpers in `internal/infrastructure/controllers/webhooks/source_ip.go`, plus a `Dispatcher.enforceSourceIPAllowlist` middleware-style helper that both webhook handlers call as their first guard
-
-### Added
+- added `Server.AllowedSourceCIDRs` (env: `CODE_GURU_SERVER_ALLOWED_SOURCE_CIDRS`) — a comma-separated CIDR allowlist enforced on `/webhooks/azuredevops` and `/webhooks/github` before any auth check; the source IP is read from `CF-Connecting-IP`, then `X-Real-IP`, then the leftmost `X-Forwarded-For` entry, then `RemoteAddr` (in that order); empty list means "no allowlist", preserving existing behaviour. CIDRs are parsed once at dispatcher construction so the per-request hot path has no parsing cost; invalid entries are logged and skipped
+- added `clientIP(*http.Request)` and `sourceIPAllowed(ip, prefixes)` helpers in `internal/infrastructure/controllers/webhooks/source_ip.go`, plus a `Dispatcher.enforceSourceIPAllowlist` middleware-style helper that both webhook handlers call as their first guard
 
 - added `deliver_docker: true` to `.github/workflows/default.yaml` so future tag pushes automatically build and publish the Docker image to `ghcr.io/rios0rios0/code-guru` alongside the binary release; previously every image bump required a manual `docker build && docker push` (see the `0.2.0` rollout for the toolbox stack)
 - added `packages: 'write'` to the workflow `permissions:` block so the `delivery-docker` job can authenticate to GHCR; reusable workflows cannot escalate beyond the caller's grants, so the permission has to be declared at the caller level

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Added
 
+- added `Server.AllowedSourceCIDRs` (env: `CODE_GURU_SERVER_ALLOWED_SOURCE_CIDRS`) — a comma-separated CIDR allowlist enforced on `/webhooks/azuredevops` and `/webhooks/github` before any auth check; the source IP is read from `CF-Connecting-IP`, then `X-Real-IP`, then the leftmost `X-Forwarded-For` entry, then `RemoteAddr` (in that order); empty list means "no allowlist", preserving existing behaviour
+- added `clientIP(*http.Request)` and `sourceIPAllowed(ip, cidrs)` helpers in `internal/infrastructure/controllers/webhooks/source_ip.go`, plus a `Dispatcher.enforceSourceIPAllowlist` middleware-style helper that both webhook handlers call as their first guard
+
+### Added
+
 - added `deliver_docker: true` to `.github/workflows/default.yaml` so future tag pushes automatically build and publish the Docker image to `ghcr.io/rios0rios0/code-guru` alongside the binary release; previously every image bump required a manual `docker build && docker push` (see the `0.2.0` rollout for the toolbox stack)
 - added `packages: 'write'` to the workflow `permissions:` block so the `delivery-docker` job can authenticate to GHCR; reusable workflows cannot escalate beyond the caller's grants, so the permission has to be declared at the caller level
 

--- a/internal/domain/entities/settings.go
+++ b/internal/domain/entities/settings.go
@@ -74,6 +74,7 @@ type ServerConfig struct {
 	ShutdownTimeout      time.Duration `yaml:"shutdown_timeout"`
 	AllowedOrganizations []string      `yaml:"allowed_organizations"`
 	AllowedProjects      []string      `yaml:"allowed_projects"`
+	AllowedSourceCIDRs   []string      `yaml:"allowed_source_cidrs"`
 }
 
 // GitHubAppConfig holds GitHub App authentication settings.
@@ -163,6 +164,7 @@ func NewSettingsFromEnv() (*Settings, error) {
 			ShutdownTimeout:      shutdownTimeout,
 			AllowedOrganizations: splitCSV(os.Getenv("CODE_GURU_SERVER_ALLOWED_ORGANIZATIONS")),
 			AllowedProjects:      splitCSV(os.Getenv("CODE_GURU_SERVER_ALLOWED_PROJECTS")),
+			AllowedSourceCIDRs:   splitCSV(os.Getenv("CODE_GURU_SERVER_ALLOWED_SOURCE_CIDRS")),
 		},
 		GitHubApp: GitHubAppConfig{
 			AppID:      appID,

--- a/internal/infrastructure/controllers/webhooks/azuredevops.go
+++ b/internal/infrastructure/controllers/webhooks/azuredevops.go
@@ -45,7 +45,17 @@ type adoProject struct {
 // Auth: Basic. ADO does not support HMAC signing on Service Hooks.
 // Supported events: git.pullrequest.created and git.pullrequest.updated for
 // active PRs. All other events return 204 No Content.
+//
+// number of validation guard clauses it has to enforce in order before
+// touching the worker queue. Splitting further would scatter the request flow
+// across multiple methods without removing any branches.
+//
+//nolint:funlen // Single-shot HTTP handler whose length is proportional to the
 func (d *Dispatcher) HandleAzureDevOps(w http.ResponseWriter, r *http.Request) {
+	if !d.enforceSourceIPAllowlist(w, r, "ADO") {
+		return
+	}
+
 	if authErr := VerifyBasicAuth(d.settings.Server.WebhookSecret, r.Header.Get("Authorization")); authErr != nil {
 		logger.Warnf("ADO webhook rejected: %v", authErr)
 		status := http.StatusUnauthorized

--- a/internal/infrastructure/controllers/webhooks/azuredevops.go
+++ b/internal/infrastructure/controllers/webhooks/azuredevops.go
@@ -46,11 +46,12 @@ type adoProject struct {
 // Supported events: git.pullrequest.created and git.pullrequest.updated for
 // active PRs. All other events return 204 No Content.
 //
-// number of validation guard clauses it has to enforce in order before
-// touching the worker queue. Splitting further would scatter the request flow
-// across multiple methods without removing any branches.
+// The handler length is driven by the number of validation guard clauses it
+// has to enforce in order before touching the worker queue. Splitting further
+// would scatter the request flow across multiple methods without removing any
+// branches.
 //
-//nolint:funlen // Single-shot HTTP handler whose length is proportional to the
+//nolint:funlen // Single-shot HTTP handler whose length is proportional to its required validation flow.
 func (d *Dispatcher) HandleAzureDevOps(w http.ResponseWriter, r *http.Request) {
 	if !d.enforceSourceIPAllowlist(w, r, "ADO") {
 		return

--- a/internal/infrastructure/controllers/webhooks/azuredevops_test.go
+++ b/internal/infrastructure/controllers/webhooks/azuredevops_test.go
@@ -198,4 +198,77 @@ func TestHandleAzureDevOps(t *testing.T) {
 		assert.Equal(t, http.StatusForbidden, w.Code)
 		assert.Empty(t, sub.Jobs())
 	})
+
+	t.Run("should respond 403 (Forbidden) when CF-Connecting-IP is outside AllowedSourceCIDRs", func(t *testing.T) {
+		// given: a settings with a strict allowlist that excludes 8.8.8.8
+		settings := defaultADOSettings()
+		settings.Server.AllowedSourceCIDRs = []string{"13.107.6.0/24", "13.107.9.0/24"}
+		d, sub := newDispatcherWithSettings(t, settings)
+		req := httptest.NewRequest(http.MethodPost, "/webhooks/azuredevops", bytes.NewBufferString(adoActivePRPayload))
+		req.Header.Set("Authorization", adoBasicAuth(adoSecret))
+		req.Header.Set("CF-Connecting-IP", "8.8.8.8")
+		w := httptest.NewRecorder()
+
+		// when
+		d.HandleAzureDevOps(w, req)
+
+		// then: rejected before basic-auth even runs, so the queue stays empty
+		assert.Equal(t, http.StatusForbidden, w.Code)
+		assert.Empty(t, sub.Jobs())
+	})
+
+	t.Run("should respond 202 (Accepted) when CF-Connecting-IP is inside AllowedSourceCIDRs", func(t *testing.T) {
+		// given
+		settings := defaultADOSettings()
+		settings.Server.AllowedSourceCIDRs = []string{"13.107.6.0/24"}
+		d, sub := newDispatcherWithSettings(t, settings)
+		req := httptest.NewRequest(http.MethodPost, "/webhooks/azuredevops", bytes.NewBufferString(adoActivePRPayload))
+		req.Header.Set("Authorization", adoBasicAuth(adoSecret))
+		req.Header.Set("CF-Connecting-IP", "13.107.6.42")
+		w := httptest.NewRecorder()
+
+		// when
+		d.HandleAzureDevOps(w, req)
+
+		// then
+		assert.Equal(t, http.StatusAccepted, w.Code)
+		assert.Len(t, sub.Jobs(), 1)
+	})
+
+	t.Run("should accept any source IP when AllowedSourceCIDRs is empty (default)", func(t *testing.T) {
+		// given: defaultADOSettings() does not set AllowedSourceCIDRs, so the
+		// list is nil — the allowlist is intentionally permissive when no
+		// CIDRs are configured.
+		d, sub := newDispatcherWithSettings(t, defaultADOSettings())
+		req := httptest.NewRequest(http.MethodPost, "/webhooks/azuredevops", bytes.NewBufferString(adoActivePRPayload))
+		req.Header.Set("Authorization", adoBasicAuth(adoSecret))
+		req.Header.Set("CF-Connecting-IP", "8.8.8.8")
+		w := httptest.NewRecorder()
+
+		// when
+		d.HandleAzureDevOps(w, req)
+
+		// then
+		assert.Equal(t, http.StatusAccepted, w.Code)
+		assert.Len(t, sub.Jobs(), 1)
+	})
+
+	t.Run("should fall back to X-Forwarded-For when CF-Connecting-IP is absent", func(t *testing.T) {
+		// given: only the leftmost XFF entry is the original client; the
+		// second entry is a proxy hop that should NOT be used for matching.
+		settings := defaultADOSettings()
+		settings.Server.AllowedSourceCIDRs = []string{"13.107.6.0/24"}
+		d, sub := newDispatcherWithSettings(t, settings)
+		req := httptest.NewRequest(http.MethodPost, "/webhooks/azuredevops", bytes.NewBufferString(adoActivePRPayload))
+		req.Header.Set("Authorization", adoBasicAuth(adoSecret))
+		req.Header.Set("X-Forwarded-For", "13.107.6.42, 10.0.0.1, 172.16.90.7")
+		w := httptest.NewRecorder()
+
+		// when
+		d.HandleAzureDevOps(w, req)
+
+		// then
+		assert.Equal(t, http.StatusAccepted, w.Code)
+		assert.Len(t, sub.Jobs(), 1)
+	})
 }

--- a/internal/infrastructure/controllers/webhooks/dispatcher.go
+++ b/internal/infrastructure/controllers/webhooks/dispatcher.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/netip"
 	"slices"
+	"strings"
 
 	forgeEntities "github.com/rios0rios0/gitforge/pkg/global/domain/entities"
 	registry "github.com/rios0rios0/gitforge/pkg/registry/infrastructure"
@@ -24,13 +26,14 @@ type Submitter interface {
 
 // Dispatcher bridges webhook events to the domain review logic.
 type Dispatcher struct {
-	aiFactory        *infraRepos.AIReviewerFactory
-	rulesFactory     *infraRepos.RulesRepositoryFactory
-	detectorRegistry repositories.TrivialDetectorRegistry
-	settings         *entities.Settings
-	providerRegistry *registry.ProviderRegistry
-	submitter        Submitter
-	githubTokenizer  GitHubTokenizer
+	aiFactory             *infraRepos.AIReviewerFactory
+	rulesFactory          *infraRepos.RulesRepositoryFactory
+	detectorRegistry      repositories.TrivialDetectorRegistry
+	settings              *entities.Settings
+	providerRegistry      *registry.ProviderRegistry
+	submitter             Submitter
+	githubTokenizer       GitHubTokenizer
+	allowedSourcePrefixes []netip.Prefix
 }
 
 // GitHubTokenizer resolves an installation access token for a GitHub App.
@@ -48,12 +51,37 @@ func NewDispatcher(
 	providerRegistry *registry.ProviderRegistry,
 ) *Dispatcher {
 	return &Dispatcher{
-		aiFactory:        aiFactory,
-		rulesFactory:     rulesFactory,
-		detectorRegistry: detectorRegistry,
-		settings:         settings,
-		providerRegistry: providerRegistry,
+		aiFactory:             aiFactory,
+		rulesFactory:          rulesFactory,
+		detectorRegistry:      detectorRegistry,
+		settings:              settings,
+		providerRegistry:      providerRegistry,
+		allowedSourcePrefixes: parseAllowedCIDRs(settings.Server.AllowedSourceCIDRs),
 	}
+}
+
+// parseAllowedCIDRs validates and parses each CIDR entry once at startup so
+// hot-path requests don't re-parse the same strings. Invalid entries are
+// logged and skipped — this keeps the dispatcher boot-able if a single typo
+// slips through, while still surfacing the problem in the operator log.
+func parseAllowedCIDRs(raw []string) []netip.Prefix {
+	if len(raw) == 0 {
+		return nil
+	}
+	parsed := make([]netip.Prefix, 0, len(raw))
+	for _, c := range raw {
+		c = strings.TrimSpace(c)
+		if c == "" {
+			continue
+		}
+		prefix, err := netip.ParsePrefix(c)
+		if err != nil {
+			logger.Warnf("dispatcher: ignoring invalid CIDR %q in Server.AllowedSourceCIDRs: %v", c, err)
+			continue
+		}
+		parsed = append(parsed, prefix)
+	}
+	return parsed
 }
 
 // SetSubmitter wires the worker pool used to enqueue review jobs. Called by the

--- a/internal/infrastructure/controllers/webhooks/github.go
+++ b/internal/infrastructure/controllers/webhooks/github.go
@@ -68,6 +68,10 @@ const fullNameSegments = 2
 // Settings.Server.WebhookSecret. Supported events: pull_request with action
 // in {opened, synchronize, reopened}.
 func (d *Dispatcher) HandleGitHub(w http.ResponseWriter, r *http.Request) {
+	if !d.enforceSourceIPAllowlist(w, r, "GitHub") {
+		return
+	}
+
 	defer func() { _ = r.Body.Close() }()
 	body, readErr := io.ReadAll(r.Body)
 	if readErr != nil {

--- a/internal/infrastructure/controllers/webhooks/github_test.go
+++ b/internal/infrastructure/controllers/webhooks/github_test.go
@@ -217,4 +217,39 @@ func TestHandleGitHub(t *testing.T) {
 		assert.Equal(t, http.StatusAccepted, w.Code)
 		require.Len(t, sub.Jobs(), 1)
 	})
+
+	t.Run("should respond 403 (Forbidden) when CF-Connecting-IP is outside AllowedSourceCIDRs", func(t *testing.T) {
+		// given: source-IP allowlist runs before HMAC verification, so an
+		// off-list request never gets a chance to brute-force the signature.
+		settings := defaultGitHubSettings()
+		settings.Server.AllowedSourceCIDRs = []string{"140.82.112.0/20"} // GitHub Hooks range example
+		d, sub := newDispatcherWithGitHubTokenizer(t, settings)
+		req := githubRequest(t, ghSecret, ghOpenedPayload, "pull_request")
+		req.Header.Set("CF-Connecting-IP", "8.8.8.8")
+		w := httptest.NewRecorder()
+
+		// when
+		d.HandleGitHub(w, req)
+
+		// then
+		assert.Equal(t, http.StatusForbidden, w.Code)
+		assert.Empty(t, sub.Jobs())
+	})
+
+	t.Run("should respond 202 (Accepted) when CF-Connecting-IP is inside AllowedSourceCIDRs", func(t *testing.T) {
+		// given
+		settings := defaultGitHubSettings()
+		settings.Server.AllowedSourceCIDRs = []string{"140.82.112.0/20"}
+		d, sub := newDispatcherWithGitHubTokenizer(t, settings)
+		req := githubRequest(t, ghSecret, ghOpenedPayload, "pull_request")
+		req.Header.Set("CF-Connecting-IP", "140.82.112.42")
+		w := httptest.NewRecorder()
+
+		// when
+		d.HandleGitHub(w, req)
+
+		// then
+		assert.Equal(t, http.StatusAccepted, w.Code)
+		assert.Len(t, sub.Jobs(), 1)
+	})
 }

--- a/internal/infrastructure/controllers/webhooks/source_ip.go
+++ b/internal/infrastructure/controllers/webhooks/source_ip.go
@@ -1,0 +1,87 @@
+package webhooks
+
+import (
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+
+	logger "github.com/sirupsen/logrus"
+)
+
+// clientIP returns the original client IP for r, preferring proxy-set headers
+// over the connection peer because the pod typically sits behind a CDN
+// (Cloudflare) and an in-cluster ingress controller. Header precedence,
+// strongest signal first:
+//
+//  1. CF-Connecting-IP — set by Cloudflare and reset on every hop, so
+//     spoofing requires bypassing Cloudflare entirely.
+//  2. X-Real-IP — typically set by a single trusted proxy in front of the pod.
+//  3. X-Forwarded-For — comma-separated chain; the leftmost entry is the
+//     original client. Trustworthy only when the upstream chain is also
+//     trusted; combine with a network-level allowlist if the threat model
+//     requires defending against forged XFF.
+//  4. r.RemoteAddr — the TCP peer, used as a last resort. In a typical
+//     ingress chain this is the load balancer or the ingress controller, not
+//     the original client.
+func clientIP(r *http.Request) string {
+	if v := strings.TrimSpace(r.Header.Get("Cf-Connecting-Ip")); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(r.Header.Get("X-Real-IP")); v != "" {
+		return v
+	}
+	if v := r.Header.Get("X-Forwarded-For"); v != "" {
+		// First entry is the original client; subsequent entries are
+		// proxy hops appended by each forwarder.
+		first, _, _ := strings.Cut(v, ",")
+		if first = strings.TrimSpace(first); first != "" {
+			return first
+		}
+	}
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return host
+	}
+	return r.RemoteAddr
+}
+
+// sourceIPAllowed returns true when ip is within any of the cidrs, or when the
+// list is empty (which means "no allowlist configured, allow all"). Empty or
+// malformed cidrs entries are skipped silently so a single bad config line
+// does not lock the whole listener out.
+func sourceIPAllowed(ip string, cidrs []string) bool {
+	if len(cidrs) == 0 {
+		return true
+	}
+	addr, parseErr := netip.ParseAddr(ip)
+	if parseErr != nil {
+		return false
+	}
+	for _, c := range cidrs {
+		prefix, prefixErr := netip.ParsePrefix(strings.TrimSpace(c))
+		if prefixErr != nil {
+			continue
+		}
+		if prefix.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}
+
+// enforceSourceIPAllowlist runs the source-IP allowlist check on r and writes
+// a 403 response when the request's source IP is outside the configured
+// CIDRs. Returns true when the request should proceed to the next handler
+// stage, false when the response has already been written.
+//
+// label is included in the warning log so operators can tell ADO and GitHub
+// rejections apart in the same stream.
+func (d *Dispatcher) enforceSourceIPAllowlist(w http.ResponseWriter, r *http.Request, label string) bool {
+	ip := clientIP(r)
+	if sourceIPAllowed(ip, d.settings.Server.AllowedSourceCIDRs) {
+		return true
+	}
+	logger.Warnf("%s webhook rejected: source IP %s not in allowlist", label, ip)
+	writeError(w, http.StatusForbidden, "source IP not allowed")
+	return false
+}

--- a/internal/infrastructure/controllers/webhooks/source_ip.go
+++ b/internal/infrastructure/controllers/webhooks/source_ip.go
@@ -9,6 +9,9 @@ import (
 	logger "github.com/sirupsen/logrus"
 )
 
+// Re-exported indirectly: source_ip.go and dispatcher.go share the
+// netip.Prefix type via the dispatcher's pre-parsed slice.
+
 // clientIP returns the original client IP for r, preferring proxy-set headers
 // over the connection peer because the pod typically sits behind a CDN
 // (Cloudflare) and an in-cluster ingress controller. Header precedence,
@@ -45,23 +48,19 @@ func clientIP(r *http.Request) string {
 	return r.RemoteAddr
 }
 
-// sourceIPAllowed returns true when ip is within any of the cidrs, or when the
-// list is empty (which means "no allowlist configured, allow all"). Empty or
-// malformed cidrs entries are skipped silently so a single bad config line
-// does not lock the whole listener out.
-func sourceIPAllowed(ip string, cidrs []string) bool {
-	if len(cidrs) == 0 {
+// sourceIPAllowed returns true when ip is within any of the prefixes, or when
+// the list is empty (which means "no allowlist configured, allow all").
+// Prefixes are pre-parsed at dispatcher construction (see parseAllowedCIDRs)
+// so this hot-path check has no per-request parsing cost.
+func sourceIPAllowed(ip string, prefixes []netip.Prefix) bool {
+	if len(prefixes) == 0 {
 		return true
 	}
 	addr, parseErr := netip.ParseAddr(ip)
 	if parseErr != nil {
 		return false
 	}
-	for _, c := range cidrs {
-		prefix, prefixErr := netip.ParsePrefix(strings.TrimSpace(c))
-		if prefixErr != nil {
-			continue
-		}
+	for _, prefix := range prefixes {
 		if prefix.Contains(addr) {
 			return true
 		}
@@ -78,7 +77,7 @@ func sourceIPAllowed(ip string, cidrs []string) bool {
 // rejections apart in the same stream.
 func (d *Dispatcher) enforceSourceIPAllowlist(w http.ResponseWriter, r *http.Request, label string) bool {
 	ip := clientIP(r)
-	if sourceIPAllowed(ip, d.settings.Server.AllowedSourceCIDRs) {
+	if sourceIPAllowed(ip, d.allowedSourcePrefixes) {
 		return true
 	}
 	logger.Warnf("%s webhook rejected: source IP %s not in allowlist", label, ip)


### PR DESCRIPTION
## Summary

The shared-toolbox deployment runs the code-guru pod behind Cloudflare → AKS load balancer → nginx-ingress. The ingress controller's `whitelist-source-range` annotation matches the **internal LB peer IP** (`172.16.90.x`), not the original ADO source IP — so the existing nginx allowlist either rejects everything (current state with the annotation removed for the smoke test) or allows everything (current state). The cluster's controller has `allow-snippet-annotations: false`, so per-ingress `configuration-snippet` to read `CF-Connecting-IP` is blocked. Cluster-wide `use-forwarded-headers: true` would change behaviour for every other ingress (Backstage, Argo CD, MISP, SonarQube, Dependency-Track) — too high blast radius.

App-layer enforcement is the cleanest path.

## What changed

- `Server.AllowedSourceCIDRs` (`yaml: allowed_source_cidrs`, env: `CODE_GURU_SERVER_ALLOWED_SOURCE_CIDRS`) on `ServerConfig`. Comma-separated CIDR list. Empty = no allowlist (current default behaviour preserved).
- `internal/infrastructure/controllers/webhooks/source_ip.go` — `clientIP(r)` extracts the source IP from headers in this order: `CF-Connecting-IP` → `X-Real-IP` → leftmost `X-Forwarded-For` → `RemoteAddr`. `sourceIPAllowed(ip, cidrs)` matches against the configured CIDRs (`net/netip` for IPv4 + IPv6).
- `Dispatcher.enforceSourceIPAllowlist(w, r, label)` middleware-style helper called as the **first guard** by both `HandleAzureDevOps` and `HandleGitHub`, before basic-auth / HMAC.
- Tests on the ADO handler cover four scenarios: outside-CIDR → 403, inside-CIDR → 202, empty list → 202 from any IP, `X-Forwarded-For` fallback uses the leftmost entry.

## Test plan

- [x] `go test -tags unit ./...` all pass
- [x] `make lint` 0 issues
- [ ] Toolbox companion PR (separate, will follow this merge) will set `CODE_GURU_SERVER_ALLOWED_SOURCE_CIDRS` to the published Azure DevOps service-tag CIDRs and the existing `var.ingress_allowed_source_ranges` will be repurposed
- [ ] After both merge: smoke-test PR in `backend/catalog`, verify pod logs show the request is accepted with the right `CF-Connecting-IP` value

## Related

Defense-in-depth alongside the existing `Server.AllowedOrganizations` and `Server.AllowedProjects` payload-level allowlists. Same code style as those two helpers in `dispatcher.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)