### PR TITLE
fix(webhook): extracted repository UUID from ADO payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Fixed
 
-- fixed `Repository ID is empty, falling back to repository name for API calls` warning emitted by the gitforge Azure DevOps provider on every webhook delivery; the ADO `git.pullrequest.created` / `updated` payload includes the repository UUID at `resource.repository.id` but the handler was not extracting it. Added `ID` to the `adoRepository` struct and now passes `forgeEntities.Repository{ID: ...}`. The fallback-to-name path still works for older provider versions or payloads missing the field
+- fixed `Repository ID is empty, falling back to repository name for API calls` warning emitted by the gitforge Azure DevOps provider on every webhook delivery; the ADO `git.pullrequest.created` / `updated` payload includes the repository UUID at `resource.repository.id` but the handler was not extracting it. Added `ID` to the `adoRepository` struct and now passes `forgeEntities.Repository{ID: ...}`. The fallback-to-name path still works when the handler receives a payload with a missing or empty `resource.repository.id`
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed `Repository ID is empty, falling back to repository name for API calls` warning emitted by the gitforge Azure DevOps provider on every webhook delivery; the ADO `git.pullrequest.created` / `updated` payload includes the repository UUID at `resource.repository.id` but the handler was not extracting it. Added `ID` to the `adoRepository` struct and now passes `forgeEntities.Repository{ID: ...}`. The fallback-to-name path still works for older provider versions or payloads missing the field
+
 ### Added
 
 - added `Server.AllowedSourceCIDRs` (env: `CODE_GURU_SERVER_ALLOWED_SOURCE_CIDRS`) — a comma-separated CIDR allowlist enforced on `/webhooks/azuredevops` and `/webhooks/github` before any auth check; the source IP is read from `CF-Connecting-IP`, then `X-Real-IP`, then the leftmost `X-Forwarded-For` entry, then `RemoteAddr` (in that order); empty list means "no allowlist", preserving existing behaviour. CIDRs are parsed once at dispatcher construction so the per-request hot path has no parsing cost; invalid entries are logged and skipped

--- a/internal/infrastructure/controllers/webhooks/azuredevops.go
+++ b/internal/infrastructure/controllers/webhooks/azuredevops.go
@@ -31,6 +31,7 @@ type adoResource struct {
 }
 
 type adoRepository struct {
+	ID        string     `json:"id"`
 	Name      string     `json:"name"`
 	RemoteURL string     `json:"remoteUrl"`
 	Project   adoProject `json:"project"`
@@ -117,6 +118,7 @@ func (d *Dispatcher) HandleAzureDevOps(w http.ResponseWriter, r *http.Request) {
 	}
 
 	repo := forgeEntities.Repository{
+		ID:           event.Resource.Repository.ID,
 		Name:         event.Resource.Repository.Name,
 		Organization: org,
 		Project:      event.Resource.Repository.Project.Name,

--- a/internal/infrastructure/controllers/webhooks/azuredevops_test.go
+++ b/internal/infrastructure/controllers/webhooks/azuredevops_test.go
@@ -5,6 +5,7 @@ package webhooks_test
 import (
 	"bytes"
 	"encoding/base64"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -69,7 +70,12 @@ func adoBasicAuth(secret string) string {
 
 const adoRepoUUID = "11111111-2222-3333-4444-555555555555"
 
-const adoActivePRPayload = `{
+// adoActivePRPayload returns the canonical ADO `git.pullrequest.created`
+// payload used across the test suite. Built via Sprintf so adoRepoUUID
+// stays the single source of truth for the repository UUID — both the
+// JSON body and any assertions compare against the same constant.
+func adoActivePRPayload() string {
+	return fmt.Sprintf(`{
   "eventType": "git.pullrequest.created",
   "resource": {
     "pullRequestId": 42,
@@ -79,13 +85,14 @@ const adoActivePRPayload = `{
     "sourceRefName": "refs/heads/feat/x",
     "targetRefName": "refs/heads/main",
     "repository": {
-      "id": "11111111-2222-3333-4444-555555555555",
+      "id": %q,
       "name": "demo-repo",
       "remoteUrl": "https://dev.azure.com/ZestSecurity/Platform/_git/demo-repo",
       "project": {"name": "Platform"}
     }
   }
-}`
+}`, adoRepoUUID)
+}
 
 func TestHandleAzureDevOps(t *testing.T) {
 	t.Parallel()
@@ -93,7 +100,7 @@ func TestHandleAzureDevOps(t *testing.T) {
 	t.Run("should respond 202 (Accepted) when an active PR is enqueued", func(t *testing.T) {
 		// given
 		d, sub := newDispatcherWithSettings(t, defaultADOSettings())
-		req := httptest.NewRequest(http.MethodPost, "/webhooks/azuredevops", bytes.NewBufferString(adoActivePRPayload))
+		req := httptest.NewRequest(http.MethodPost, "/webhooks/azuredevops", bytes.NewBufferString(adoActivePRPayload()))
 		req.Header.Set("Authorization", adoBasicAuth(adoSecret))
 		w := httptest.NewRecorder()
 
@@ -116,7 +123,7 @@ func TestHandleAzureDevOps(t *testing.T) {
 	t.Run("should respond 401 (Unauthorized) when basic auth is wrong", func(t *testing.T) {
 		// given
 		d, sub := newDispatcherWithSettings(t, defaultADOSettings())
-		req := httptest.NewRequest(http.MethodPost, "/webhooks/azuredevops", bytes.NewBufferString(adoActivePRPayload))
+		req := httptest.NewRequest(http.MethodPost, "/webhooks/azuredevops", bytes.NewBufferString(adoActivePRPayload()))
 		req.Header.Set("Authorization", adoBasicAuth("wrong"))
 		w := httptest.NewRecorder()
 
@@ -131,7 +138,7 @@ func TestHandleAzureDevOps(t *testing.T) {
 	t.Run("should respond 400 (Bad Request) when the auth header is missing", func(t *testing.T) {
 		// given
 		d, _ := newDispatcherWithSettings(t, defaultADOSettings())
-		req := httptest.NewRequest(http.MethodPost, "/webhooks/azuredevops", bytes.NewBufferString(adoActivePRPayload))
+		req := httptest.NewRequest(http.MethodPost, "/webhooks/azuredevops", bytes.NewBufferString(adoActivePRPayload()))
 		w := httptest.NewRecorder()
 
 		// when
@@ -192,7 +199,7 @@ func TestHandleAzureDevOps(t *testing.T) {
 		settings := defaultADOSettings()
 		settings.Server.AllowedProjects = []string{"OtherProject"}
 		d, sub := newDispatcherWithSettings(t, settings)
-		req := httptest.NewRequest(http.MethodPost, "/webhooks/azuredevops", bytes.NewBufferString(adoActivePRPayload))
+		req := httptest.NewRequest(http.MethodPost, "/webhooks/azuredevops", bytes.NewBufferString(adoActivePRPayload()))
 		req.Header.Set("Authorization", adoBasicAuth(adoSecret))
 		w := httptest.NewRecorder()
 
@@ -209,7 +216,7 @@ func TestHandleAzureDevOps(t *testing.T) {
 		settings := defaultADOSettings()
 		settings.Server.AllowedSourceCIDRs = []string{"13.107.6.0/24", "13.107.9.0/24"}
 		d, sub := newDispatcherWithSettings(t, settings)
-		req := httptest.NewRequest(http.MethodPost, "/webhooks/azuredevops", bytes.NewBufferString(adoActivePRPayload))
+		req := httptest.NewRequest(http.MethodPost, "/webhooks/azuredevops", bytes.NewBufferString(adoActivePRPayload()))
 		req.Header.Set("Authorization", adoBasicAuth(adoSecret))
 		req.Header.Set("CF-Connecting-IP", "8.8.8.8")
 		w := httptest.NewRecorder()
@@ -227,7 +234,7 @@ func TestHandleAzureDevOps(t *testing.T) {
 		settings := defaultADOSettings()
 		settings.Server.AllowedSourceCIDRs = []string{"13.107.6.0/24"}
 		d, sub := newDispatcherWithSettings(t, settings)
-		req := httptest.NewRequest(http.MethodPost, "/webhooks/azuredevops", bytes.NewBufferString(adoActivePRPayload))
+		req := httptest.NewRequest(http.MethodPost, "/webhooks/azuredevops", bytes.NewBufferString(adoActivePRPayload()))
 		req.Header.Set("Authorization", adoBasicAuth(adoSecret))
 		req.Header.Set("CF-Connecting-IP", "13.107.6.42")
 		w := httptest.NewRecorder()
@@ -245,7 +252,7 @@ func TestHandleAzureDevOps(t *testing.T) {
 		// list is nil — the allowlist is intentionally permissive when no
 		// CIDRs are configured.
 		d, sub := newDispatcherWithSettings(t, defaultADOSettings())
-		req := httptest.NewRequest(http.MethodPost, "/webhooks/azuredevops", bytes.NewBufferString(adoActivePRPayload))
+		req := httptest.NewRequest(http.MethodPost, "/webhooks/azuredevops", bytes.NewBufferString(adoActivePRPayload()))
 		req.Header.Set("Authorization", adoBasicAuth(adoSecret))
 		req.Header.Set("CF-Connecting-IP", "8.8.8.8")
 		w := httptest.NewRecorder()
@@ -264,7 +271,7 @@ func TestHandleAzureDevOps(t *testing.T) {
 		settings := defaultADOSettings()
 		settings.Server.AllowedSourceCIDRs = []string{"13.107.6.0/24"}
 		d, sub := newDispatcherWithSettings(t, settings)
-		req := httptest.NewRequest(http.MethodPost, "/webhooks/azuredevops", bytes.NewBufferString(adoActivePRPayload))
+		req := httptest.NewRequest(http.MethodPost, "/webhooks/azuredevops", bytes.NewBufferString(adoActivePRPayload()))
 		req.Header.Set("Authorization", adoBasicAuth(adoSecret))
 		req.Header.Set("X-Forwarded-For", "13.107.6.42, 10.0.0.1, 172.16.90.7")
 		w := httptest.NewRecorder()

--- a/internal/infrastructure/controllers/webhooks/azuredevops_test.go
+++ b/internal/infrastructure/controllers/webhooks/azuredevops_test.go
@@ -67,6 +67,8 @@ func adoBasicAuth(secret string) string {
 	return "Basic " + base64.StdEncoding.EncodeToString([]byte(webhooks.BasicAuthUsername+":"+secret))
 }
 
+const adoRepoUUID = "11111111-2222-3333-4444-555555555555"
+
 const adoActivePRPayload = `{
   "eventType": "git.pullrequest.created",
   "resource": {
@@ -77,6 +79,7 @@ const adoActivePRPayload = `{
     "sourceRefName": "refs/heads/feat/x",
     "targetRefName": "refs/heads/main",
     "repository": {
+      "id": "11111111-2222-3333-4444-555555555555",
       "name": "demo-repo",
       "remoteUrl": "https://dev.azure.com/ZestSecurity/Platform/_git/demo-repo",
       "project": {"name": "Platform"}
@@ -103,6 +106,8 @@ func TestHandleAzureDevOps(t *testing.T) {
 		require.Len(t, jobs, 1)
 		assert.Equal(t, 42, jobs[0].PR.ID)
 		assert.Equal(t, adoRepoName, jobs[0].Repo.Name)
+		assert.Equal(t, adoRepoUUID, jobs[0].Repo.ID,
+			"Repo.ID must be populated from resource.repository.id so the gitforge ADO provider can use the UUID instead of falling back to the repo name")
 		assert.Equal(t, adoProjectName, jobs[0].Repo.Project)
 		assert.Equal(t, adoOrgSlug, jobs[0].Repo.Organization)
 		assert.False(t, jobs[0].CIPassed)


### PR DESCRIPTION
## Summary

Every webhook delivery on the deployed pod logs:

```
Repository ID is empty, falling back to repository name for API calls (repoName=catalog)
```

That warning comes from `gitforge`'s ADO provider when `forgeEntities.Repository.ID == ""`. The ADO `git.pullrequest.created` / `updated` payload **does** include the repository UUID at `resource.repository.id`, but the `adoRepository` struct in our handler wasn't parsing it.

## What changed

- Added `ID string \`json:"id"\`` to `adoRepository`.
- Pass `event.Resource.Repository.ID` into `forgeEntities.Repository{ID: ...}`.
- Test payload extended with a fixture UUID; the existing happy-path test asserts the ID makes it onto the enqueued job.

The gitforge fallback to repo name is preserved (it still kicks in when the field is empty), so older payloads or providers that don't set the field continue to work.

## Test plan

- [x] `go test -tags unit ./internal/infrastructure/controllers/webhooks/...` — pass
- [x] `make lint` — 0 issues
- [ ] After this merges + new image rolls, `kubectl logs deploy/code-guru -n code-guru --since=10m` after a webhook should no longer contain `Repository ID is empty`

🤖 Generated with [Claude Code](https://claude.com/claude-code)