### PR TITLE
fix(review): suppress PR-wide summary thread when inline comments exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- changed `ReviewCommand.postComments` to suppress the PR-wide summary thread whenever the review carries one or more inline comments; observed on `backend/warden-http#11977` where every push produced a duplicate summary thread on top of the per-file inline threads, so reviewers saw a fresh "summary" comment accumulate next to the same inline feedback after each commit. The summary is still posted when `result.Comments` is empty (clean reviews / `verdict=approve`) so the operator retains a visible signal that the bot ran. Decision is centralised in `commands.shouldPostSummary` (exposed via `export_test.go`) so the gate is unit-testable without standing up the full `Execute` flow with stubs
+
 ### Fixed
 
 - fixed `code-guru` posting the raw model output as a single PR-wide thread when the AI returned malformed JSON; observed on `backend/authenticator#12027` thread `71418` where the model emitted `"body":"... Rule: Go Logging — "Always use \`WithFields\` ..."."` with unescaped `"` characters inside the string value. `json.Unmarshal` rejected it, the markdown-fence regex missed (the model honoured the "no fences" instruction), and `ParseReviewResponse` defaulted to `Verdict="comment"` plus `Summary=raw response` — which `postComments` then dumped onto the PR as a 3.5 KB JSON blob. Added a `repairJSONStrings` state-machine pass that escapes any `"` whose lookahead is not a JSON structural token (`,`, `:`, `}`, `]`, or end of input); valid JSON round-trips unchanged. On total parse failure the parser now logs the raw content (truncated to `4096` bytes) at `ERROR` and returns `support.ErrUnparseableResponse` so the worker logs the failure and posts nothing — instead of fabricating a comment from the broken response

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,16 +18,13 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Changed
 
-- changed `ReviewCommand.postComments` to suppress the PR-wide summary thread whenever the review carries one or more inline comments; observed on `backend/warden-http#11977` where every push produced a duplicate summary thread on top of the per-file inline threads, so reviewers saw a fresh "summary" comment accumulate next to the same inline feedback after each commit. The summary is still posted when `result.Comments` is empty (clean reviews / `verdict=approve`) so the operator retains a visible signal that the bot ran. Decision is centralised in `commands.shouldPostSummary` (exposed via `export_test.go`) so the gate is unit-testable without standing up the full `Execute` flow with stubs
+- changed `ReviewCommand.postComments` to suppress the PR-wide summary thread whenever the review carries one or more per-issue comments (inline `Line > 0` threads or PR-wide `Line <= 0` annotations); observed on `backend/warden-http#11977` where every push produced a duplicate summary thread on top of the per-file inline threads, so reviewers saw a fresh "summary" comment accumulate next to the same per-issue feedback after each commit. The summary is still posted when `result.Comments` is empty (clean reviews / `verdict=approve`) so the operator retains a visible signal that the bot ran. Decision is centralised in `commands.shouldPostSummary` (exposed via `export_test.go`) so the gate is unit-testable without standing up the full `Execute` flow with stubs
+- changed `support.ParseReviewResponse` so it no longer falls back to `&ReviewResult{Summary: content}` on a parse failure — that fallback is what allowed the malformed-JSON dump described below to reach the PR. Callers that depended on the previous "always returns a result" contract (the three AI reviewer repositories — `claude`, `openai`, `anthropic`) propagate the new error up through `ReviewDiff`; the worker layer already logs and swallows reviewer errors, so a parse failure now manifests as a log line and an absent comment rather than a noisy thread
+- changed the Go module dependencies to their latest versions
 
 ### Fixed
 
 - fixed `code-guru` posting the raw model output as a single PR-wide thread when the AI returned malformed JSON; observed on `backend/authenticator#12027` thread `71418` where the model emitted `"body":"... Rule: Go Logging — "Always use \`WithFields\` ..."."` with unescaped `"` characters inside the string value. `json.Unmarshal` rejected it, the markdown-fence regex missed (the model honoured the "no fences" instruction), and `ParseReviewResponse` defaulted to `Verdict="comment"` plus `Summary=raw response` — which `postComments` then dumped onto the PR as a 3.5 KB JSON blob. Added a `repairJSONStrings` state-machine pass that escapes any `"` whose lookahead is not a JSON structural token (`,`, `:`, `}`, `]`, or end of input); valid JSON round-trips unchanged. On total parse failure the parser now logs the raw content (truncated to `4096` bytes) at `ERROR` and returns `support.ErrUnparseableResponse` so the worker logs the failure and posts nothing — instead of fabricating a comment from the broken response
-
-### Changed
-
-- changed `support.ParseReviewResponse` so it no longer falls back to `&ReviewResult{Summary: content}` on a parse failure — that fallback is what allowed the malformed-JSON dump described above to reach the PR. Callers that depended on the previous "always returns a result" contract (the three AI reviewer repositories — `claude`, `openai`, `anthropic`) propagate the new error up through `ReviewDiff`; the worker layer already logs and swallows reviewer errors, so a parse failure now manifests as a log line and an absent comment rather than a noisy thread
-- changed the Go module dependencies to their latest versions
 
 ## [1.4.0] - 2026-04-29
 

--- a/internal/domain/commands/export_test.go
+++ b/internal/domain/commands/export_test.go
@@ -1,0 +1,11 @@
+//go:build unit
+
+package commands
+
+// ShouldPostSummary exposes the unexported `shouldPostSummary` predicate to
+// the external `commands_test` package so the gating decision can be unit
+// tested without standing up the full `Execute` flow with stubs for every
+// repository/provider/registry. The variable indirection keeps the helper
+// itself unexported in production builds (the file is gated on the `unit`
+// build tag).
+var ShouldPostSummary = shouldPostSummary

--- a/internal/domain/commands/review_command.go
+++ b/internal/domain/commands/review_command.go
@@ -258,7 +258,13 @@ func (c *ReviewCommand) postComments(
 	prID int,
 	result *entities.ReviewResult,
 ) {
-	if result.Summary != "" {
+	// Post the PR-wide summary only when there are no inline comments. The
+	// inline threads already carry the per-issue feedback, so an extra
+	// summary thread on every push is pure noise that accumulates as
+	// reviewers push fixes. The summary is still posted for clean reviews
+	// (`verdict=approve` with empty Comments) so the operator can see that
+	// the bot ran and concluded with no issues.
+	if shouldPostSummary(result) {
 		if err := provider.PostPullRequestComment(ctx, repo, prID, result.Summary); err != nil {
 			logger.Errorf("failed to post summary comment: %v", err)
 		}
@@ -279,6 +285,17 @@ func (c *ReviewCommand) postComments(
 			}
 		}
 	}
+}
+
+// shouldPostSummary decides whether the PR-wide summary thread should be
+// emitted alongside the per-file inline threads. The summary is suppressed
+// whenever there are inline comments because each push otherwise produces a
+// fresh duplicate summary even when the inline feedback already covers the
+// same issues. A non-empty summary with zero inline comments is still
+// posted so clean reviews (`verdict=approve`, "no issues found") leave a
+// visible signal that the bot ran.
+func shouldPostSummary(result *entities.ReviewResult) bool {
+	return result.Summary != "" && len(result.Comments) == 0
 }
 
 func allDiffsEmpty(diffs []entities.FileDiff) bool {

--- a/internal/domain/commands/review_command.go
+++ b/internal/domain/commands/review_command.go
@@ -258,12 +258,13 @@ func (c *ReviewCommand) postComments(
 	prID int,
 	result *entities.ReviewResult,
 ) {
-	// Post the PR-wide summary only when there are no inline comments. The
-	// inline threads already carry the per-issue feedback, so an extra
-	// summary thread on every push is pure noise that accumulates as
-	// reviewers push fixes. The summary is still posted for clean reviews
-	// (`verdict=approve` with empty Comments) so the operator can see that
-	// the bot ran and concluded with no issues.
+	// Post the PR-wide summary only when there are no per-issue comments
+	// (neither inline `Line > 0` threads nor PR-wide `Line <= 0`
+	// annotations). The per-issue comments already carry the feedback, so
+	// an extra summary thread on every push is pure noise that accumulates
+	// as reviewers push fixes. The summary is still posted for clean
+	// reviews (`verdict=approve` with empty `Comments`) so the operator can
+	// see that the bot ran and concluded with no issues.
 	if shouldPostSummary(result) {
 		if err := provider.PostPullRequestComment(ctx, repo, prID, result.Summary); err != nil {
 			logger.Errorf("failed to post summary comment: %v", err)
@@ -288,12 +289,14 @@ func (c *ReviewCommand) postComments(
 }
 
 // shouldPostSummary decides whether the PR-wide summary thread should be
-// emitted alongside the per-file inline threads. The summary is suppressed
-// whenever there are inline comments because each push otherwise produces a
-// fresh duplicate summary even when the inline feedback already covers the
-// same issues. A non-empty summary with zero inline comments is still
-// posted so clean reviews (`verdict=approve`, "no issues found") leave a
-// visible signal that the bot ran.
+// emitted alongside the per-issue comments. The summary is suppressed
+// whenever `result.Comments` is non-empty — that is, whenever the review
+// carries any per-issue feedback, regardless of whether each item lands as
+// an inline thread (`Line > 0`) or a PR-wide annotation (`Line <= 0`).
+// Each push otherwise produced a fresh duplicate summary even when the
+// per-issue feedback already covered the same content. A non-empty summary
+// with zero comments is still posted so clean reviews (`verdict=approve`,
+// "no issues found") leave a visible signal that the bot ran.
 func shouldPostSummary(result *entities.ReviewResult) bool {
 	return result.Summary != "" && len(result.Comments) == 0
 }

--- a/internal/domain/commands/review_command_test.go
+++ b/internal/domain/commands/review_command_test.go
@@ -63,17 +63,18 @@ func TestShouldPostSummary(t *testing.T) {
 		assert.False(t, ok, "summary must not be posted when the summary string is empty")
 	})
 
-	t.Run("should suppress summary when summary is empty even though inline comments are absent", func(t *testing.T) {
-		// given: an empty-summary result must not produce a blank PR-wide
-		// thread regardless of the comments slice shape.
+	t.Run("should treat a whitespace-only summary as non-empty (current contract)", func(t *testing.T) {
+		// given: the predicate's emptiness check is `Summary != ""`, so a
+		// whitespace-only summary is considered non-empty and posted when
+		// `Comments` is empty. Pin this behaviour so a future change to
+		// trim or treat whitespace as empty is deliberate and arrives with
+		// an explicit test update.
 		result := &entities.ReviewResult{Summary: "   ", Comments: nil}
 
 		// when
 		ok := commands.ShouldPostSummary(result)
 
-		// then: whitespace-only summaries are still treated as non-empty by
-		// the predicate today (it checks `!= ""`); this test pins that
-		// behaviour so a future change has to be deliberate.
-		assert.True(t, ok, "current contract: any non-empty Summary string is posted when no inline comments exist")
+		// then
+		assert.True(t, ok, "whitespace-only Summary is treated as non-empty and posted when Comments is empty")
 	})
 }

--- a/internal/domain/commands/review_command_test.go
+++ b/internal/domain/commands/review_command_test.go
@@ -1,0 +1,79 @@
+//go:build unit
+
+package commands_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/rios0rios0/codeguru/internal/domain/commands"
+	"github.com/rios0rios0/codeguru/internal/domain/entities"
+)
+
+func TestShouldPostSummary(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should suppress summary when inline comments are present", func(t *testing.T) {
+		// given: the user's complaint on `backend/warden-http#11977` was that
+		// every push produced a duplicate PR-wide summary thread on top of
+		// the per-file inline threads. Skipping the summary in this case is
+		// the entire point of the gate.
+		result := &entities.ReviewResult{
+			Summary: "Found a few issues",
+			Comments: []entities.ReviewComment{
+				{FilePath: "main.go", Line: 10, Severity: "warning", Body: "..."},
+			},
+		}
+
+		// when
+		ok := commands.ShouldPostSummary(result)
+
+		// then
+		assert.False(t, ok, "summary must not be re-posted when inline comments already cover the issues")
+	})
+
+	t.Run("should post summary when there are no inline comments", func(t *testing.T) {
+		// given: clean reviews (`verdict=approve`, "no issues found") still
+		// need a visible signal that the bot ran — otherwise the operator
+		// has no easy way to tell whether the webhook fired at all.
+		result := &entities.ReviewResult{
+			Verdict:  "approve",
+			Summary:  "No issues found.",
+			Comments: nil,
+		}
+
+		// when
+		ok := commands.ShouldPostSummary(result)
+
+		// then
+		assert.True(t, ok, "summary must still be posted when the review has no inline comments")
+	})
+
+	t.Run("should suppress summary when both summary and comments are empty", func(t *testing.T) {
+		// given: a degenerate empty result — neither summary nor comments —
+		// must produce no PR thread at all. Posting an empty summary would
+		// leave a blank thread on the PR.
+		result := &entities.ReviewResult{Summary: "", Comments: nil}
+
+		// when
+		ok := commands.ShouldPostSummary(result)
+
+		// then
+		assert.False(t, ok, "summary must not be posted when the summary string is empty")
+	})
+
+	t.Run("should suppress summary when summary is empty even though inline comments are absent", func(t *testing.T) {
+		// given: an empty-summary result must not produce a blank PR-wide
+		// thread regardless of the comments slice shape.
+		result := &entities.ReviewResult{Summary: "   ", Comments: nil}
+
+		// when
+		ok := commands.ShouldPostSummary(result)
+
+		// then: whitespace-only summaries are still treated as non-empty by
+		// the predicate today (it checks `!= ""`); this test pins that
+		// behaviour so a future change has to be deliberate.
+		assert.True(t, ok, "current contract: any non-empty Summary string is posted when no inline comments exist")
+	})
+}


### PR DESCRIPTION
## Summary

Every push on `backend/warden-http#11977` produced a fresh duplicate summary thread on top of the per-file inline threads — three or four near-identical "Found a few issues" threads stacked up while the reviewer pushed fixes, even though the inline threads already carried the per-issue feedback.

This PR gates the PR-wide summary post on `len(result.Comments) == 0`. Inline-driven reviews (the common case) drop the summary entirely; clean reviews (`verdict=approve` / "no issues found") keep posting the summary so the operator retains a visible signal that the bot ran.

## Files

- `internal/domain/commands/review_command.go` — added `shouldPostSummary(*ReviewResult) bool` and routed `postComments` through it.
- `internal/domain/commands/export_test.go` (`//go:build unit`) — re-exposes the predicate to the external test package.
- `internal/domain/commands/review_command_test.go` — four cases: inline-comments-suppress, no-inline-keeps, both-empty-suppress, whitespace-only-summary contract pin.

## Test plan

- [x] `go test -tags unit ./...` — passes
- [x] `make lint` — 0 issues
- [ ] After deploy, the next push on a PR with inline-feedback-style review produces no PR-wide summary thread
- [ ] A clean-review PR (no comments) still produces a single "no issues found" summary thread

## Related

Surfaced together with two other concerns the user reported on `warden-http#11977`:

1. **Wrong mapper rule** — bot enforced struct-based mappers but the team's convention is functions only. That's a `rios0rios0/guide@generated:claude/rules/golang.md` change (lines 129-145), **not** a `code-guru` change. Tracked separately.
2. **JSON-blob comments on parse failure** — fixed in `code-guru#90` (the parser-repair PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)