### PR TITLE
chore(ai): defaulted ai.submit_native_review to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- changed the default of `ai.submit_native_review` from `false` to `true` so deployments that have not wired the flag pick up native pull request reviews (Approved / Changes Requested in the platform's reviewer panel) automatically. Operators that want the previous text-only behaviour now opt out explicitly with `submit_native_review: false` in YAML or `CODE_GURU_AI_SUBMIT_NATIVE_REVIEW=false`. Implemented as a tri-state `*bool` on `AIConfig.SubmitNativeReview` plus a new `AIConfig.NativeReviewSubmissionEnabled()` helper that resolves nil (the YAML / env "unset" state) to `true`; all three call sites (`review_controller.go`, `review_all_controller.go`, `webhooks/dispatcher.go`) now go through the helper. Pinned by six new test rows covering the resolver (`nil → true`, explicit `true`, explicit `false`) and the env-only path (unset → nil + default ON, explicit `false` → resolved off, unparseable typo → nil + default ON so a typo cannot silently flip behaviour)
+
+
 ### Added
 
 - added native pull request review submission so the bot's verdict surfaces in the platform's reviewer panel (Approved / Changes Requested) instead of only inside the completion annotation. After every trivial-detector verdict and every successful AI review, `ReviewCommand` now also calls `gitforge.SubmitPullRequestReview` — GitHub uses the `event` field on `POST /pulls/:n/reviews` (`APPROVE` / `REQUEST_CHANGES`), Azure DevOps uses the integer reviewer vote on `PUT /pullrequests/:id/reviewers/:reviewerId` (`10` / `-10`). Gated by the new `ai.submit_native_review` setting (default `false`); flip via YAML or `CODE_GURU_AI_SUBMIT_NATIVE_REVIEW=true`. Best-effort: a provider failure logs at `Warn` and the existing text annotation still posts. The `comment` verdict deliberately skips the API call so an AI review with no opinion does not flip a previous Approved/Changes-Requested vote on the next push. The verdict-to-`forgeEntities.ReviewSubmission` translation lives in the new `support.MapVerdictToReview` helper, covered by table-driven unit tests in `internal/support/verdict_mapper_test.go`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,6 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
-### Changed
-
-- changed the default of `ai.submit_native_review` from `false` to `true` so deployments that have not wired the flag pick up native pull request reviews (Approved / Changes Requested in the platform's reviewer panel) automatically. Operators that want the previous text-only behaviour now opt out explicitly with `submit_native_review: false` in YAML or `CODE_GURU_AI_SUBMIT_NATIVE_REVIEW=false`. Implemented as a tri-state `*bool` on `AIConfig.SubmitNativeReview` plus a new `AIConfig.NativeReviewSubmissionEnabled()` helper that resolves nil (the YAML / env "unset" state) to `true`; all three call sites (`review_controller.go`, `review_all_controller.go`, `webhooks/dispatcher.go`) now go through the helper. Pinned by six new test rows covering the resolver (`nil → true`, explicit `true`, explicit `false`) and the env-only path (unset → nil + default ON, explicit `false` → resolved off, unparseable typo → nil + default ON so a typo cannot silently flip behaviour)
-
-
 ### Added
 
 - added native pull request review submission so the bot's verdict surfaces in the platform's reviewer panel (Approved / Changes Requested) instead of only inside the completion annotation. After every trivial-detector verdict and every successful AI review, `ReviewCommand` now also calls `gitforge.SubmitPullRequestReview` — GitHub uses the `event` field on `POST /pulls/:n/reviews` (`APPROVE` / `REQUEST_CHANGES`), Azure DevOps uses the integer reviewer vote on `PUT /pullrequests/:id/reviewers/:reviewerId` (`10` / `-10`). Gated by the new `ai.submit_native_review` setting (default `false`); flip via YAML or `CODE_GURU_AI_SUBMIT_NATIVE_REVIEW=true`. Best-effort: a provider failure logs at `Warn` and the existing text annotation still posts. The `comment` verdict deliberately skips the API call so an AI review with no opinion does not flip a previous Approved/Changes-Requested vote on the next push. The verdict-to-`forgeEntities.ReviewSubmission` translation lives in the new `support.MapVerdictToReview` helper, covered by table-driven unit tests in `internal/support/verdict_mapper_test.go`
@@ -28,6 +23,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Changed
 
+- changed the default of `ai.submit_native_review` from `false` to `true` so deployments that have not wired the flag pick up native pull request reviews (Approved / Changes Requested in the platform's reviewer panel) automatically. Operators that want the previous text-only behaviour now opt out explicitly with `submit_native_review: false` in YAML or `CODE_GURU_AI_SUBMIT_NATIVE_REVIEW=false`. Implemented as a tri-state `*bool` on `AIConfig.SubmitNativeReview` plus a new `AIConfig.NativeReviewSubmissionEnabled()` helper that resolves nil (the YAML / env "unset" state) to `true`; all three call sites (`review_controller.go`, `review_all_controller.go`, `webhooks/dispatcher.go`) now go through the helper. Pinned by six new test rows covering the resolver (`nil → true`, explicit `true`, explicit `false`) and the env-only path (unset → nil + default ON, explicit `false` → resolved off, unparseable typo → nil + default ON so a typo cannot silently flip behaviour)
 - bumped `gitforge` to the post-`SubmitPullRequestReview` revision so the new `ReviewProvider.SubmitPullRequestReview` method and `PullRequestDetail.IsDraft` field are available; this is also the breaking-change boundary where Azure DevOps' `ListOpenPullRequests` stopped filtering drafts client-side (the policy now lives in `ReviewCommand`)
 
 ## [1.5.0] - 2026-05-01

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ providers:
 
 ai:
   backend: 'claude'
-  # When true, the bot also records a native pull request review (Approved /
-  # Changes Requested) on the platform's reviewer panel in addition to the
-  # text completion annotation. Defaults to false.
-  submit_native_review: false
+  # When the bot records a native pull request review (Approved / Changes
+  # Requested) on the platform's reviewer panel in addition to the text
+  # completion annotation. Defaults to true; set to false to opt out.
+  submit_native_review: true
   # When false (the default), draft PRs are skipped entirely — set to true to
   # opt back in.
   review_drafts: false
@@ -362,7 +362,7 @@ For CI/CD environments without a config file, all settings can be provided via `
 | `CODE_GURU_RULES_PATH`                | Path to rules directory                                                  |                      |
 | `CODE_GURU_PROVIDER_TOKEN`            | Git provider token                                                       |                      |
 | `CODE_GURU_TRIVIAL_ADAPTERS`          | Comma-separated adapter names                                            |                      |
-| `CODE_GURU_AI_SUBMIT_NATIVE_REVIEW`   | When `true`, also records a native review (Approved / Changes Requested) on the platform's reviewer panel | `false`              |
+| `CODE_GURU_AI_SUBMIT_NATIVE_REVIEW`   | Records a native review (Approved / Changes Requested) on the platform's reviewer panel; set to `false` to opt out | `true`               |
 | `CODE_GURU_AI_REVIEW_DRAFTS`          | When `true`, the bot reviews draft PRs as well — by default drafts are skipped | `false`              |
 
 ## Rules

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ providers:
 
 ai:
   backend: 'claude'
-  # When the bot records a native pull request review (Approved / Changes
-  # Requested) on the platform's reviewer panel in addition to the text
-  # completion annotation. Defaults to true; set to false to opt out.
+  # When true, the bot also records a native pull request review (Approved /
+  # Changes Requested) on the platform's reviewer panel in addition to the
+  # text completion annotation. Defaults to true; set to false to opt out.
   submit_native_review: true
   # When false (the default), draft PRs are skipped entirely — set to true to
   # opt back in.

--- a/internal/domain/commands/review_command.go
+++ b/internal/domain/commands/review_command.go
@@ -37,7 +37,8 @@ type ReviewOptions struct {
 	// surfaces in the platform's reviewer panel rather than only in the
 	// completion annotation. Best-effort: a failure to submit logs at warn
 	// and the existing text annotation still posts. Wired from
-	// settings.AI.SubmitNativeReview at each call site.
+	// settings.AI.NativeReviewSubmissionEnabled() at each call site, which
+	// resolves the tri-state YAML / env config (default true).
 	SubmitNativeReview bool
 
 	// ReviewDrafts, when false, causes Execute to short-circuit on draft

--- a/internal/domain/entities/settings.go
+++ b/internal/domain/entities/settings.go
@@ -33,22 +33,40 @@ type AIConfig struct {
 	Claude    ClaudeConfig    `yaml:"claude"`
 	Anthropic AnthropicConfig `yaml:"anthropic"`
 
-	// SubmitNativeReview, when true, asks the bot to record a native pull
-	// request review (Approved / Changes Requested) on GitHub or Azure
-	// DevOps in addition to the existing text-only completion annotation.
-	// Comment-only verdicts are not submitted as native reviews
-	// (support.MapVerdictToReview returns ok=false for them). The native
-	// review surfaces the verdict in the platform's reviewer panel.
-	// Defaults to false so existing deployments keep their previous
-	// behaviour until operators explicitly opt in. Override via
-	// CODE_GURU_AI_SUBMIT_NATIVE_REVIEW=true.
-	SubmitNativeReview bool `yaml:"submit_native_review"`
+	// SubmitNativeReview, when set, controls whether the bot also records
+	// a native pull request review (Approved / Changes Requested) on
+	// GitHub or Azure DevOps. Comment-only verdicts are not submitted as
+	// native reviews (support.MapVerdictToReview returns ok=false for
+	// them). The native review surfaces the verdict in the platform's
+	// reviewer panel.
+	//
+	// Tri-state pointer so YAML / env "unset" can mean "use the default":
+	// nil resolves to true via NativeReviewSubmissionEnabled (default ON).
+	// Operators that want to opt out explicitly set
+	// `submit_native_review: false` in YAML or
+	// CODE_GURU_AI_SUBMIT_NATIVE_REVIEW=false. Call sites should always
+	// read the resolved value via NativeReviewSubmissionEnabled rather
+	// than dereferencing the pointer directly.
+	SubmitNativeReview *bool `yaml:"submit_native_review"`
 
 	// ReviewDrafts, when true, lets the bot review draft PRs as well. By
 	// default draft PRs are skipped — most teams treat drafts as
 	// work-in-progress that should not consume review budget. Override via
 	// CODE_GURU_AI_REVIEW_DRAFTS=true.
 	ReviewDrafts bool `yaml:"review_drafts"`
+}
+
+// NativeReviewSubmissionEnabled resolves the tri-state SubmitNativeReview
+// pointer into a single boolean. nil (the YAML / env "unset" state) returns
+// true so deployments that never wire the flag pick up the new default
+// behaviour automatically; an explicit `submit_native_review: false` in YAML
+// or `CODE_GURU_AI_SUBMIT_NATIVE_REVIEW=false` returns false. Callers should
+// always go through this helper rather than dereferencing the pointer.
+func (a AIConfig) NativeReviewSubmissionEnabled() bool {
+	if a.SubmitNativeReview == nil {
+		return true
+	}
+	return *a.SubmitNativeReview
 }
 
 // OpenAIConfig holds OpenAI-specific settings.
@@ -165,7 +183,7 @@ func NewSettingsFromEnv() (*Settings, error) {
 				APIKey: os.Getenv("CODE_GURU_ANTHROPIC_API_KEY"),
 				Model:  envOrDefault("CODE_GURU_ANTHROPIC_MODEL", "claude-sonnet-4-20250514"),
 			},
-			SubmitNativeReview: parseBoolEnv("CODE_GURU_AI_SUBMIT_NATIVE_REVIEW", false),
+			SubmitNativeReview: parseOptionalBoolEnv("CODE_GURU_AI_SUBMIT_NATIVE_REVIEW"),
 			ReviewDrafts:       parseBoolEnv("CODE_GURU_AI_REVIEW_DRAFTS", false),
 		},
 		Rules: RulesConfig{
@@ -248,6 +266,23 @@ func parseBoolEnv(key string, fallback bool) bool {
 		return fallback
 	}
 	return parsed
+}
+
+// parseOptionalBoolEnv reads a tri-state boolean env var. An unset variable
+// returns nil so downstream resolvers (e.g. NativeReviewSubmissionEnabled)
+// can apply their default. A set-but-unparseable value also returns nil so
+// a typo does not silently flip behaviour — operators see the default
+// instead. Truthy values follow the [strconv.ParseBool] defaults.
+func parseOptionalBoolEnv(key string) *bool {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return nil
+	}
+	parsed, err := strconv.ParseBool(raw)
+	if err != nil {
+		return nil
+	}
+	return &parsed
 }
 
 // splitCSV parses a comma-separated string into a slice, trimming whitespace and skipping empties.

--- a/internal/domain/entities/settings.go
+++ b/internal/domain/entities/settings.go
@@ -255,9 +255,11 @@ func envOrDefault(key, fallback string) string {
 // parseBoolEnv reads a boolean environment variable. Truthy values are the
 // strconv defaults (`1`, `t`, `true` — case-insensitive); any non-empty value
 // the parser rejects falls back to the provided default rather than panicking,
-// so a typo does not silently flip behaviour.
+// so a typo does not silently flip behaviour. Surrounding whitespace is
+// trimmed before parsing so values shipped via Helm/templating (which often
+// leave a trailing newline or space, e.g. `"false "`) parse correctly.
 func parseBoolEnv(key string, fallback bool) bool {
-	raw := os.Getenv(key)
+	raw := strings.TrimSpace(os.Getenv(key))
 	if raw == "" {
 		return fallback
 	}
@@ -269,12 +271,17 @@ func parseBoolEnv(key string, fallback bool) bool {
 }
 
 // parseOptionalBoolEnv reads a tri-state boolean env var. An unset variable
-// returns nil so downstream resolvers (e.g. NativeReviewSubmissionEnabled)
-// can apply their default. A set-but-unparseable value also returns nil so
-// a typo does not silently flip behaviour — operators see the default
-// instead. Truthy values follow the [strconv.ParseBool] defaults.
+// (or one that is whitespace-only after trimming) returns nil so downstream
+// resolvers (e.g. NativeReviewSubmissionEnabled) can apply their default. A
+// set-but-unparseable value also returns nil so a typo does not silently
+// flip behaviour — operators see the default instead. Truthy values follow
+// the [strconv.ParseBool] defaults. Surrounding whitespace is trimmed before
+// parsing so Helm-rendered values like `"false "` survive the round-trip and
+// the operator's explicit opt-out is honoured (without trimming, ParseBool
+// would reject the trailing space and the resolver would fall back to the
+// default ON, which is exactly the silent flip this branch tries to avoid).
 func parseOptionalBoolEnv(key string) *bool {
-	raw := os.Getenv(key)
+	raw := strings.TrimSpace(os.Getenv(key))
 	if raw == "" {
 		return nil
 	}

--- a/internal/domain/entities/settings_test.go
+++ b/internal/domain/entities/settings_test.go
@@ -201,4 +201,25 @@ func TestNewSettingsFromEnvNativeReviewDefault(t *testing.T) {
 		assert.Nil(t, settings.AI.SubmitNativeReview)
 		assert.True(t, settings.AI.NativeReviewSubmissionEnabled())
 	})
+
+	t.Run("should honour an explicit opt-out shipped with surrounding whitespace (Helm templating)", func(t *testing.T) {
+		// given: Helm / templating frequently injects a trailing newline
+		// or space when rendering values into a Pod's env. Without
+		// trimming, `strconv.ParseBool("false ")` errors and the
+		// resolver falls back to the default ON — silently flipping the
+		// operator's explicit opt-out into the very behaviour they
+		// disabled. Pin the trim contract here.
+		t.Setenv("CODE_GURU_BACKEND", "openai")
+		t.Setenv("CODE_GURU_OPENAI_API_KEY", "test-key-123")
+		t.Setenv("CODE_GURU_AI_SUBMIT_NATIVE_REVIEW", "false \n")
+
+		// when
+		settings, err := entities.NewSettingsFromEnv()
+
+		// then
+		require.NoError(t, err)
+		require.NotNil(t, settings.AI.SubmitNativeReview)
+		assert.False(t, *settings.AI.SubmitNativeReview)
+		assert.False(t, settings.AI.NativeReviewSubmissionEnabled())
+	})
 }

--- a/internal/domain/entities/settings_test.go
+++ b/internal/domain/entities/settings_test.go
@@ -108,3 +108,97 @@ func TestNewSettingsFromEnv(t *testing.T) {
 		assert.Equal(t, "openai", settings.AI.Backend)
 	})
 }
+
+func TestNativeReviewSubmissionEnabled(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should default to true when SubmitNativeReview is nil", func(t *testing.T) {
+		t.Parallel()
+
+		// given: nil pointer mirrors the YAML / env "unset" state — pin
+		// this default so a future refactor that flips the polarity has
+		// to update this test deliberately.
+		ai := entities.AIConfig{SubmitNativeReview: nil}
+
+		// when
+		got := ai.NativeReviewSubmissionEnabled()
+
+		// then
+		assert.True(t, got, "unset SubmitNativeReview must resolve to true (the default-ON contract)")
+	})
+
+	t.Run("should return true when SubmitNativeReview points to true", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		v := true
+		ai := entities.AIConfig{SubmitNativeReview: &v}
+
+		// when / then
+		assert.True(t, ai.NativeReviewSubmissionEnabled())
+	})
+
+	t.Run("should return false only when operator explicitly opts out via false", func(t *testing.T) {
+		t.Parallel()
+
+		// given: explicit `submit_native_review: false` in YAML or
+		// CODE_GURU_AI_SUBMIT_NATIVE_REVIEW=false is the documented
+		// opt-out path.
+		v := false
+		ai := entities.AIConfig{SubmitNativeReview: &v}
+
+		// when / then
+		assert.False(t, ai.NativeReviewSubmissionEnabled())
+	})
+}
+
+func TestNewSettingsFromEnvNativeReviewDefault(t *testing.T) {
+	t.Run("should leave SubmitNativeReview nil when the env var is not set so the default ON path takes over", func(t *testing.T) {
+		// given: a minimal env-only configuration with no
+		// CODE_GURU_AI_SUBMIT_NATIVE_REVIEW setting at all.
+		t.Setenv("CODE_GURU_BACKEND", "openai")
+		t.Setenv("CODE_GURU_OPENAI_API_KEY", "test-key-123")
+
+		// when
+		settings, err := entities.NewSettingsFromEnv()
+
+		// then: the field stays nil so NativeReviewSubmissionEnabled
+		// returns the documented default (true) without operator action.
+		require.NoError(t, err)
+		assert.Nil(t, settings.AI.SubmitNativeReview,
+			"unset CODE_GURU_AI_SUBMIT_NATIVE_REVIEW must leave the pointer nil so the default-ON resolver fires")
+		assert.True(t, settings.AI.NativeReviewSubmissionEnabled())
+	})
+
+	t.Run("should resolve to false when the operator explicitly sets the env var to false", func(t *testing.T) {
+		// given
+		t.Setenv("CODE_GURU_BACKEND", "openai")
+		t.Setenv("CODE_GURU_OPENAI_API_KEY", "test-key-123")
+		t.Setenv("CODE_GURU_AI_SUBMIT_NATIVE_REVIEW", "false")
+
+		// when
+		settings, err := entities.NewSettingsFromEnv()
+
+		// then
+		require.NoError(t, err)
+		require.NotNil(t, settings.AI.SubmitNativeReview)
+		assert.False(t, *settings.AI.SubmitNativeReview)
+		assert.False(t, settings.AI.NativeReviewSubmissionEnabled())
+	})
+
+	t.Run("should leave the pointer nil on an unparseable env value so the default applies", func(t *testing.T) {
+		// given: a typo (anything strconv.ParseBool rejects) must not
+		// silently flip behaviour — we want the default ON, not OFF.
+		t.Setenv("CODE_GURU_BACKEND", "openai")
+		t.Setenv("CODE_GURU_OPENAI_API_KEY", "test-key-123")
+		t.Setenv("CODE_GURU_AI_SUBMIT_NATIVE_REVIEW", "yesplease")
+
+		// when
+		settings, err := entities.NewSettingsFromEnv()
+
+		// then
+		require.NoError(t, err)
+		assert.Nil(t, settings.AI.SubmitNativeReview)
+		assert.True(t, settings.AI.NativeReviewSubmissionEnabled())
+	})
+}

--- a/internal/infrastructure/controllers/review_all_controller.go
+++ b/internal/infrastructure/controllers/review_all_controller.go
@@ -90,7 +90,7 @@ func (c *ReviewAllController) Execute(cmd *cobra.Command, _ []string) {
 	results, err := reviewAllCmd.Execute(ctx, settings, commands.ReviewOptions{
 		DryRun:             dryRun,
 		Verbose:            verbose,
-		SubmitNativeReview: settings.AI.SubmitNativeReview,
+		SubmitNativeReview: settings.AI.NativeReviewSubmissionEnabled(),
 		ReviewDrafts:       settings.AI.ReviewDrafts,
 	})
 	if err != nil {

--- a/internal/infrastructure/controllers/review_controller.go
+++ b/internal/infrastructure/controllers/review_controller.go
@@ -137,7 +137,7 @@ func (c *ReviewController) Execute(cmd *cobra.Command, args []string) {
 		DryRun:             dryRun,
 		Verbose:            verbose,
 		CIPassed:           ciPassed,
-		SubmitNativeReview: settings.AI.SubmitNativeReview,
+		SubmitNativeReview: settings.AI.NativeReviewSubmissionEnabled(),
 		ReviewDrafts:       settings.AI.ReviewDrafts,
 	})
 	if err != nil {

--- a/internal/infrastructure/controllers/webhooks/dispatcher.go
+++ b/internal/infrastructure/controllers/webhooks/dispatcher.go
@@ -207,7 +207,7 @@ func (d *Dispatcher) HandlePR(
 
 	result, err := reviewCmd.Execute(ctx, provider, repo, pr, commands.ReviewOptions{
 		CIPassed:           ciPassed,
-		SubmitNativeReview: d.settings.AI.SubmitNativeReview,
+		SubmitNativeReview: d.settings.AI.NativeReviewSubmissionEnabled(),
 		ReviewDrafts:       d.settings.AI.ReviewDrafts,
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

- Flips the default of `ai.submit_native_review` from `false` to `true` so deployments that don't explicitly wire the flag pick up native PR reviews (Approved / Changes Requested in the platform's reviewer panel) automatically.
- Implemented as a tri-state `*bool` on `AIConfig.SubmitNativeReview` plus a new `AIConfig.NativeReviewSubmissionEnabled()` helper — `nil` (the YAML / env "unset" state) resolves to `true`.
- Operators that want the previous text-only behaviour now opt out explicitly with `submit_native_review: false` or `CODE_GURU_AI_SUBMIT_NATIVE_REVIEW=false`.
- `ai.review_drafts` stays at `false` (drafts skipped by default).

## Behaviour matrix

| Config | Resolved |
|---|---|
| no YAML key, no env var | `true` (new default) |
| `submit_native_review: true` / env `=true` | `true` |
| `submit_native_review: false` / env `=false` | `false` |
| env var set to a typo (`yesplease`) | `true` (default; typo does not silently flip behaviour) |

## Test plan

- [x] `make lint` — 0 issues
- [x] `make test` — full suite green
- [x] New tests: `TestNativeReviewSubmissionEnabled` (resolver: nil → true, true → true, false → false) + `TestNewSettingsFromEnvNativeReviewDefault` (env unset, env = `false`, env = typo)
- [ ] Smoke-test on a real PR after merge by leaving the flag unset and confirming the bot's vote appears in the GitHub / Azure DevOps reviewer panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)