### PR TITLE
chore(deps): bumped gitforge to the connectionData fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- bumped `gitforge` to the post-`SubmitPullRequestReview` connectionData-API-version fix (gitforge `#91`) so Azure DevOps' reviewer-ID lookup actually succeeds. Without this bump the `request_changes` and `comment` mapping additions from `#112` would still hit `failed to resolve reviewer ID: API error (status 400) VssInvalidPreviewVersionException` on every native review submission
+
 ### Fixed
 
 - fixed `support.MapVerdictToReview` so the LLM-vocabulary `request_changes` verdict (emitted by `internal/support/response_parser.go`) translates to `forgeEntities.ReviewVerdictRequestChanges` instead of silently skipping the native review submission. Captured live in dev pod logs at `2026-05-01T21:13Z` where every PR with `verdict=request_changes` (including `internal-app/internal-integrator#11957` and `internal-terraform/internal-customer-app#12159`) finished with the text annotation but never set the bot's vote in the reviewer panel — the mapper only knew the trivial-detector vocabulary (`reject`) and the bug was operationally invisible because it had no error to log

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require github.com/rios0rios0/cliforge v0.3.5
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/rios0rios0/gitforge v0.9.7-0.20260501183614-d2ca8a11348e
+	github.com/rios0rios0/gitforge v0.9.7-0.20260501232308-3711bf85d3db
 	github.com/rios0rios0/langforge v0.6.4
 	github.com/rios0rios0/testkit v0.2.0
 	github.com/sashabaranov/go-openai v1.41.2

--- a/go.sum
+++ b/go.sum
@@ -110,8 +110,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rios0rios0/cliforge v0.3.5 h1:ZuYVvHx1WfhhIKuTtoBgUbnBd0mjimOmR8SBSh+1ATc=
 github.com/rios0rios0/cliforge v0.3.5/go.mod h1:tD9lsg7s220JZBR6dpho4HwU3nN4Tk9VS9PRLvngKKw=
-github.com/rios0rios0/gitforge v0.9.7-0.20260501183614-d2ca8a11348e h1:F302oslt6L3Y0o3IvXdvVCRe4QTYvELTCXWc1IE7Vl4=
-github.com/rios0rios0/gitforge v0.9.7-0.20260501183614-d2ca8a11348e/go.mod h1:ZB504xobtj+VtAipMS3zCSkDL0R+enkYATO6cy1LhT8=
+github.com/rios0rios0/gitforge v0.9.7-0.20260501232308-3711bf85d3db h1:R3NKlP2FFFIPbw38yi9P5gqB7AOQkSSIIMbSz1h1oss=
+github.com/rios0rios0/gitforge v0.9.7-0.20260501232308-3711bf85d3db/go.mod h1:ZB504xobtj+VtAipMS3zCSkDL0R+enkYATO6cy1LhT8=
 github.com/rios0rios0/langforge v0.6.4 h1:h4oveXaSr5TSJ/xoE5EOTeuH31PHq1TCtIqqFmL+hDE=
 github.com/rios0rios0/langforge v0.6.4/go.mod h1:QHefw3xS25KCg5lYRgKXjfNdTstFQNO3tWogSHYFyo4=
 github.com/rios0rios0/testkit v0.2.0 h1:HT03bSFmpyLt8SRnPQD1cJk66mHWIV7QY0gI/fnTCLo=


### PR DESCRIPTION
## Summary

Bumps `gitforge` from `v0.9.7-0.20260501183614-d2ca8a11348e` (pre-#91) to `v0.9.7-0.20260501232308-3711bf85d3db` (post-#91 merge).

Without this bump:
- Azure DevOps `/_apis/connectionData` keeps using `api-version=7.0` and fails with HTTP 400 `VssInvalidPreviewVersionException` on every reviewer-ID lookup.
- The verdict-mapping fixes from #112 (`request_changes` → `RequestChanges`, `comment` → `WaitingForAuthor`) reach `SubmitPullRequestReview` but the underlying provider call still errors out at the connectionData step.

After this bump, native review submission should actually surface in the platform's reviewer panel on every PR review.

## Test plan

- [x] `go build ./...` clean
- [x] `make test` — all green
- [x] `make lint` — 0 issues
- [ ] Smoke-test on a real PR after rollout: confirm vote `10` for approve, vote `-10` for request_changes, vote `-5` for comment on Azure DevOps; equivalent events on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)