### PR TITLE
chore(deps): bumped gitforge to the post-ListPullRequestComments fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Changed
 
-- bumped `gitforge` to the post-`ListPullRequestComments` revision so the `ReviewProvider.ListPullRequestComments` method backing the review-once gate, mention handler, and comment dedup is available
+- bumped `gitforge` to the post-`ListPullRequestComments` revision (now includes the Azure DevOps `X-Ms-Continuationtoken` pagination fix and the GitHub provider's corrected `ThreadID` mapping that walks the `in_reply_to_id` chain instead of reusing `pull_request_review_id`) so the review-once gate, mention handler, and comment dedup all see the full comment list and group inline threads correctly
 
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require github.com/rios0rios0/cliforge v0.3.5
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/rios0rios0/gitforge v0.9.7-0.20260502021424-29fbc8ca405f
+	github.com/rios0rios0/gitforge v0.9.7-0.20260502024930-8a99adfc0a70
 	github.com/rios0rios0/langforge v0.6.4
 	github.com/rios0rios0/testkit v0.2.0
 	github.com/sashabaranov/go-openai v1.41.2

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/rios0rios0/gitforge v0.9.7-0.20260501232308-3711bf85d3db h1:R3NKlP2FF
 github.com/rios0rios0/gitforge v0.9.7-0.20260501232308-3711bf85d3db/go.mod h1:ZB504xobtj+VtAipMS3zCSkDL0R+enkYATO6cy1LhT8=
 github.com/rios0rios0/gitforge v0.9.7-0.20260502021424-29fbc8ca405f h1:y95yXqwhT2BdkhmVAlelXUijQEyzn/pLrPzz/tJkxP4=
 github.com/rios0rios0/gitforge v0.9.7-0.20260502021424-29fbc8ca405f/go.mod h1:ZB504xobtj+VtAipMS3zCSkDL0R+enkYATO6cy1LhT8=
+github.com/rios0rios0/gitforge v0.9.7-0.20260502024930-8a99adfc0a70 h1:XIErq5PeSv8ddgkkMUVCvaFXrrNHt9MwlkJ1L17lKxM=
+github.com/rios0rios0/gitforge v0.9.7-0.20260502024930-8a99adfc0a70/go.mod h1:ZB504xobtj+VtAipMS3zCSkDL0R+enkYATO6cy1LhT8=
 github.com/rios0rios0/langforge v0.6.4 h1:h4oveXaSr5TSJ/xoE5EOTeuH31PHq1TCtIqqFmL+hDE=
 github.com/rios0rios0/langforge v0.6.4/go.mod h1:QHefw3xS25KCg5lYRgKXjfNdTstFQNO3tWogSHYFyo4=
 github.com/rios0rios0/testkit v0.2.0 h1:HT03bSFmpyLt8SRnPQD1cJk66mHWIV7QY0gI/fnTCLo=


### PR DESCRIPTION
## Summary

Bumps `gitforge` from `v0.9.7-0.20260502021424-29fbc8ca405f` (the open-PR HEAD that #115 was pinned to) to `v0.9.7-0.20260502024930-8a99adfc0a70` (gitforge main post-#92 merge).

The new HEAD includes two Copilot-review fixes that landed before #92 merged:

- **ADO `X-Ms-Continuationtoken` pagination** on `ListPullRequestComments` — without this, PRs with enough discussion to spill onto a second threads page returned an incomplete comment set, breaking both the F2 review-once gate (might miss the marker on a busy PR) and the F3 inline comment dedup (might fail to dedup against a previous-page comment).
- **GitHub `ThreadID` derivation corrected** — now walks the `in_reply_to_id` chain to the root comment instead of reusing `pull_request_review_id` (which would have merged unrelated inline threads from the same review submission into one bucket and broken downstream walks).

## Test plan

- [x] `go build ./...` clean
- [x] `make test` — all green
- [x] `make lint` — 0 issues
- [ ] Smoke-test on dev once merged: trigger a re-review on a PR that already has 100+ comments and confirm the bot sees them all (proves the pagination fix is live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)