### PR TITLE
chore(deps): bump gitforge to pick up rebaseMerge ADO mergeStrategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- bumped `github.com/rios0rios0/gitforge` to `v1.0.1-0.20260504201352-69d6aef74a00` (post-merge `feat/ado-merge-strategy-rebase-merge`) to pick up the new `"rebaseMerge"` -> ADO mergeStrategy `4` mapping. Without this bump, deployments setting `CODE_GURU_TRIVIAL_MERGE_STRATEGY=rebaseMerge` would be silently downgraded to `squash` by the previous gitforge default fallback. Pairs with the dev cluster Terraform change that adds `CODE_GURU_TRIVIAL_MERGE_STRATEGY=rebaseMerge` so the trivial fast path can complete PRs through Azure DevOps branch policies that require "Rebase with merge commit" as the only allowed strategy
+
 ### Added
 
 - added `Settings.Trivial.AutoMerge` (env `CODE_GURU_TRIVIAL_AUTO_MERGE`, default `false`) and `Settings.Trivial.MergeStrategy` (env `CODE_GURU_TRIVIAL_MERGE_STRATEGY`, empty falls back to platform default) so a trivial-approve verdict can optionally complete the PR via `provider.MergePullRequest`. Off by default — the gate is "operator must explicitly opt in" because auto-merge bypasses human review and merges cross-system. A merge failure degrades gracefully: the trivial-approve verdict still stands and a warn log captures the error so the PR author can finish the merge manually. Pinned by `TestTrivialFastPathPostsSingleMarkerAndOptionalMerge` (auto-merge fires on approve, skipped on the default `false`, skipped on a `reject` verdict even with `AutoMerge=true`) and two new `TestNewSettings*` rows that verify env-overlay precedence

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require github.com/rios0rios0/cliforge v0.3.5
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/rios0rios0/gitforge v1.0.0
+	github.com/rios0rios0/gitforge v1.0.1-0.20260504201352-69d6aef74a00
 	github.com/rios0rios0/langforge v0.6.5
 	github.com/rios0rios0/testkit v0.2.0
 	github.com/sashabaranov/go-openai v1.41.2

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rios0rios0/cliforge v0.3.5 h1:ZuYVvHx1WfhhIKuTtoBgUbnBd0mjimOmR8SBSh+1ATc=
 github.com/rios0rios0/cliforge v0.3.5/go.mod h1:tD9lsg7s220JZBR6dpho4HwU3nN4Tk9VS9PRLvngKKw=
-github.com/rios0rios0/gitforge v1.0.0 h1:9zptCSKlPWQ+hE6olhKI6Rp8axo1Tn+r4f97XTRFqfY=
-github.com/rios0rios0/gitforge v1.0.0/go.mod h1:ZB504xobtj+VtAipMS3zCSkDL0R+enkYATO6cy1LhT8=
+github.com/rios0rios0/gitforge v1.0.1-0.20260504201352-69d6aef74a00 h1:1EBGNK3v8ig4R6LyngxsExNXsZm0wiBoQziReRSn+iE=
+github.com/rios0rios0/gitforge v1.0.1-0.20260504201352-69d6aef74a00/go.mod h1:ZB504xobtj+VtAipMS3zCSkDL0R+enkYATO6cy1LhT8=
 github.com/rios0rios0/langforge v0.6.5 h1:Do5R955inmd8PxlmRfHwMThAhlRhfoqUUIj8ipm7Euk=
 github.com/rios0rios0/langforge v0.6.5/go.mod h1:GTdO1ziuYrLec+Nqf+1vOfbxo5zgYCSW7mrmYsIeC1E=
 github.com/rios0rios0/testkit v0.2.0 h1:HT03bSFmpyLt8SRnPQD1cJk66mHWIV7QY0gI/fnTCLo=


### PR DESCRIPTION
## Summary

Bumps `github.com/rios0rios0/gitforge` to a post-merge commit of the [`feat/ado-merge-strategy-rebase-merge`](https://github.com/rios0rios0/gitforge/pull/95) branch so the new `"rebaseMerge"` → ADO mergeStrategy `4` mapping is available.

## Why

Without this bump, deployments setting `CODE_GURU_TRIVIAL_MERGE_STRATEGY=rebaseMerge` were silently downgraded to `squash` by the previous gitforge default fallback — which the dev branch policy on `main` then rejected with:

```
API error (status 403): Unable to complete the pull request.
The chosen merge type is forbidden by policy.
GitPullRequestUpdateRejectedByPolicyException
```

Pairs with the toolbox Terraform change that adds `CODE_GURU_TRIVIAL_MERGE_STRATEGY=rebaseMerge` so the trivial fast path can auto-merge through ADO branch policies that require "Rebase with merge commit" as the only allowed strategy.

## Test plan

- [x] `go test -tags unit ./...` green
- [x] `make lint` 0 issues
- [ ] After merge + dev rollout + Terraform apply: a `docs-only` smoke PR auto-merges through the policy-restricted branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)