### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,10 +18,11 @@ The project follows **Clean Architecture** with strict layer separation:
   - `commands/` — Use-case implementations (`ReviewCommand`, `ReviewAllCommand`, `DiscoverCommand`, `AuthCommand`, `SelfUpdateCommand`, `VersionCommand`).
 - **`internal/infrastructure/`** — Concrete implementations of domain interfaces.
   - `repositories/` — AI backend implementations (`anthropic/`, `claude/`, `openai/`), rule loading (`rules/`), trivial PR detectors (`trivial/`), OAuth token storage (`auth/`), self-updater (`selfupdate/`). A `container.go` at this level provides `AIReviewerFactory` and `RulesRepositoryFactory` for settings-driven backend selection.
-  - `controllers/` — Cobra CLI controllers (review, review-all, discover, auth, serve, self-update, version) that bridge CLI input to domain commands.
-  - `controllers/webhooks/` — HTTP webhook dispatcher with auth (`auth.go`: HMAC-SHA256 + Basic Auth), per-vendor handlers (`github.go`, `azuredevops.go`), GitHub App installation token exchange (`installation_token_exchange.go`: RS256 JWT, `sync.Map` cache), and a bounded async worker pool (`worker.go`).
-- **`internal/support/`** — Shared utility functions (URL parsing, diff splitting, file classification, prompt building).
+  - `controllers/` — Cobra CLI controllers (review, review-all, discover, auth, serve, health, self-update, version) that bridge CLI input to domain commands.
+  - `controllers/webhooks/` — HTTP webhook dispatcher (`dispatcher.go`) with auth (`auth.go`: HMAC-SHA256 + Basic Auth), per-vendor handlers (`github.go`, `azuredevops.go`), webhook dedup (`dedup_cache.go`: per-pod TTL cache; `dedup_lease.go`: K8s Lease cross-pod dedup), CIDR allowlist (`source_ip.go`), ADO skinny-payload hydration (`azuredevops_hydrator.go`), GitHub App installation token exchange (`installation_token_exchange.go`: RS256 JWT, `sync.Map` cache), and a bounded async worker pool (`worker.go`).
+- **`internal/support/`** — Shared utility functions: URL parsing, diff splitting, file classification, prompt building, response parsing, conversation assembly (prior bot review threads for re-review context), review markers and mention detection, verdict-to-native-review mapping, byte-bounded text truncation.
 - **`test/domain/doubles/`** — Test doubles (stubs) for domain repository interfaces.
+- **`test/infrastructure/doubles/`** — Test doubles for infrastructure-only types (e.g., webhook `Submitter`, `GitHubTokenizer`, `WebhookDedup`).
 - **`configs/`** — Example YAML configuration files.
 
 ## Dependency Injection
@@ -57,7 +58,7 @@ Controllers are automatically registered as subcommands via the DI container.
 - **Package naming**: Test files use the `_test` suffix on the package name (e.g., `package support_test`).
 - **Framework**: Use `github.com/stretchr/testify/assert` and `github.com/stretchr/testify/require` for assertions.
 - **Structure**: Follow Given-When-Then with `// given`, `// when`, `// then` comments. Use table-driven tests with `t.Run()` subtests. Call `t.Parallel()` at the top of test functions.
-- **Test doubles**: Place stubs in `test/domain/doubles/repositories/`. Name them with the `Stub` prefix (e.g., `StubAIReviewerRepository`). Stubs store the last request and return canned responses.
+- **Test doubles**: Place stubs in `test/domain/doubles/repositories/` for domain-contract stubs and `test/infrastructure/doubles/repositories/` for stubs that double infrastructure-only types. Name them with the `Stub` prefix (e.g., `StubAIReviewerRepository`). Stubs store the last request and return canned responses. Keep the layer the stub references on the same side of the import boundary.
 
 ## Logging
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 ### Changed
 
 - changed the Go module dependencies to their latest versions
+- refreshed `CLAUDE.md` and `.github/copilot-instructions.md` to document the webhook dispatcher, dedup cache/lease, source IP allowlist, ADO hydrator, health controller, and the four support utilities (`conversation.go`, `review_marker.go`, `verdict_mapper.go`, `truncate.go`) added since 1.5.0
 
 ## [1.7.0] - 2026-05-08
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,8 @@ Clean Architecture with domain/infrastructure separation, using Uber DIG for dep
 - `commands/` — Business logic: `ReviewCommand` (single PR with trivial detection), `ReviewAllCommand` (batch), `DiscoverCommand` (list PRs), `AuthCommand` (OAuth login/logout/status), `SelfUpdateCommand`, `VersionCommand`
 
 ### Infrastructure Layer (`internal/infrastructure/`)
-- `controllers/` — Cobra CLI controllers implementing `entities.Controller`: review, review-all, discover, auth, serve, self-update, version
-- `controllers/webhooks/` — Functional HTTP webhook stack: `auth.go` (HMAC-SHA256 + HTTP Basic helpers), `github.go` and `azuredevops.go` (vendor handlers that parse payloads and enqueue jobs), `installation_token_exchange.go` (GitHub App JWT/installation-token exchanger with cache), `worker.go` (bounded async worker pool with graceful drain)
+- `controllers/` — Cobra CLI controllers implementing `entities.Controller`: review, review-all, discover, auth, serve, health, self-update, version
+- `controllers/webhooks/` — Functional HTTP webhook stack: `auth.go` (HMAC-SHA256 + HTTP Basic helpers), `github.go` and `azuredevops.go` (vendor handlers that parse payloads and enqueue jobs), `dispatcher.go` (webhook job dispatcher wiring handlers, dedup, and worker pool), `dedup_cache.go` + `dedup_lease.go` (per-pod TTL cache + K8s Lease cross-pod dedup), `source_ip.go` (CIDR allowlist enforcement), `azuredevops_hydrator.go` (REST hydration of skinny org-wide ADO webhook payloads), `installation_token_exchange.go` (GitHub App JWT/installation-token exchanger with cache), `worker.go` (bounded async worker pool with graceful drain)
 - `repositories/anthropic/` — Anthropic Messages API backend (direct `net/http` calls)
 - `repositories/claude/` — Claude Code CLI backend (invokes `claude --print`)
 - `repositories/openai/` — OpenAI Chat Completions API backend
@@ -49,7 +49,7 @@ Clean Architecture with domain/infrastructure separation, using Uber DIG for dep
 - `repositories/container.go` — `AIReviewerFactory` and `RulesRepositoryFactory` for settings-driven backend selection
 
 ### Support Package (`internal/support/`)
-Shared utilities: `diff_splitter.go` (parse unified diffs), `file_classifier.go` (detect language via langforge), `url_parser.go` (parse PR URLs via gitforge), `prompt_builder.go` (build AI system/user prompts), `response_parser.go` (shared JSON response parsing for all AI backends)
+Shared utilities: `diff_splitter.go` (parse unified diffs), `file_classifier.go` (detect language via langforge), `url_parser.go` (parse PR URLs via gitforge), `prompt_builder.go` (build AI system/user prompts), `response_parser.go` (shared JSON response parsing for all AI backends), `conversation.go` (assemble prior bot review threads for re-review context), `review_marker.go` (review completion markers and `@code-guru` mention detection), `verdict_mapper.go` (map AI/trivial verdicts to native review submissions), `truncate.go` (byte-bounded text truncation for log lines and PR comments)
 
 ### Dependency Injection
 Each layer has a `container.go` with `RegisterProviders(*dig.Container) error`. Registration order: repositories → entities → commands → controllers → app. Entry point: `cmd/code-guru/dig.go`.


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.