### PR TITLE
fix(trivial): a CHANGELOG-only change is a version bump, not docs/update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 - changed the Go module dependencies to their latest versions
 
+### Fixed
+
+- fixed trivial-PR detection classifying a `CHANGELOG.md`-only change as `docs-only` (and as a dependency `update-*`), which let a version-bump PR be auto-approved even when the `bump-*` adapters were disabled — the changelog sits in every detector's allowed set, so the bump was claimed by whichever non-bump detector ran first. A change that touches only the changelog is now recognised as a version bump and is claimed **exclusively** by the `bump-*` detectors; `docs-only` and `update-*` still match when a genuine document or dependency manifest accompanies the changelog
+
 ## [1.8.1] - 2026-06-09
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Clean Architecture with domain/infrastructure separation, using Uber DIG for dep
 - `repositories/claude/` — Claude Code CLI backend (invokes `claude --print`)
 - `repositories/openai/` — OpenAI Chat Completions API backend
 - `repositories/rules/` — Loads Markdown rule files from filesystem with YAML frontmatter glob filtering
-- `repositories/trivial/` — Built-in trivial PR detectors: `update-go`, `update-node`, `update-python` (dependency updates), `bump-go`, `bump-node`, `bump-python` (version bumps with `.autobump.yaml` validation), `docs-only`
+- `repositories/trivial/` — Built-in trivial PR detectors: `update-go`, `update-node`, `update-python` (dependency updates), `bump-go`, `bump-node`, `bump-python` (version bumps with `.autobump.yaml` validation), `docs-only`. A `CHANGELOG.md`-only change is classified as a version bump and claimed **exclusively** by the `bump-*` detectors (shared `isChangelogOnly` guard in `registry.go`); `docs-only`/`update-*` decline it, so disabling the `bump-*` adapters reliably keeps version bumps out of trivial auto-merge instead of letting them fall through to `docs-only`/`update-*`
 - `repositories/trivial/autobump/` — Parser for `.autobump.yaml` config files used by bump detectors
 - `repositories/auth/` — Filesystem-based OAuth token storage
 - `repositories/selfupdate/` — CLI binary self-updater via cliforge

--- a/README.md
+++ b/README.md
@@ -186,7 +186,9 @@ These detect version bump (release ceremony) PRs. If the repo contains an `.auto
 
 | Adapter        | Matches When                                                    |
 |----------------|-----------------------------------------------------------------|
-| `docs-only`    | Only `*.md` files changed                                       |
+| `docs-only`    | Only `*.md` files changed (excluding a `CHANGELOG.md`-only change — see note) |
+
+> **Note — a changelog-only change is a version bump.** A PR that touches **only** `CHANGELOG.md` is the signature of a version bump / release ceremony, so it is matched **exclusively** by the `bump-*` adapters. The `docs-only` and `update-*` adapters decline it: the changelog may still *accompany* a documentation or dependency change, but it can never be the sole trigger. This means disabling the `bump-*` adapters reliably keeps version bumps out of trivial auto-merge, instead of having them silently fall through to `docs-only` or `update-*`.
 
 ### Configuration
 

--- a/internal/infrastructure/repositories/trivial/docs_only_detector.go
+++ b/internal/infrastructure/repositories/trivial/docs_only_detector.go
@@ -17,6 +17,11 @@ func (d *DocsOnlyDetector) Name() string {
 }
 
 // Detect checks whether all changed files are Markdown files.
+//
+// A change that touches ONLY the CHANGELOG is a version-bump / release
+// artifact, not documentation, so it is declined here and left to the
+// bump-* detectors (see isChangelogOnly). The CHANGELOG may still
+// accompany a genuine docs PR (e.g. README.md + CHANGELOG.md).
 func (d *DocsOnlyDetector) Detect(_ context.Context, dctx repositories.DetectionContext) repositories.DetectionResult {
 	if len(dctx.Files) == 0 {
 		return repositories.DetectionResult{}
@@ -25,6 +30,9 @@ func (d *DocsOnlyDetector) Detect(_ context.Context, dctx repositories.Detection
 		if !strings.HasSuffix(strings.ToLower(f), ".md") {
 			return repositories.DetectionResult{}
 		}
+	}
+	if isChangelogOnly(dctx.Files) {
+		return repositories.DetectionResult{}
 	}
 	return repositories.DetectionResult{
 		Detected: true,

--- a/internal/infrastructure/repositories/trivial/registry.go
+++ b/internal/infrastructure/repositories/trivial/registry.go
@@ -2,6 +2,8 @@ package trivial
 
 import (
 	"context"
+	"path/filepath"
+	"strings"
 
 	"github.com/rios0rios0/codeguru/internal/domain/entities"
 	"github.com/rios0rios0/codeguru/internal/domain/repositories"
@@ -16,6 +18,33 @@ const (
 	verdictReject  = "reject"
 	changelogFile  = "CHANGELOG.md"
 )
+
+// isChangelogOnly reports whether every changed file is the CHANGELOG.
+//
+// A change that touches ONLY the CHANGELOG is the signature of a version
+// bump / release ceremony — exactly what the bump-* detectors exist to
+// claim (e.g. bump-go = CHANGELOG.md only, since Go versions via git
+// tags). The docs-only and update-* detectors must therefore decline a
+// CHANGELOG-only change: it is neither documentation nor a dependency
+// update. Treating it as either would auto-approve a version bump even
+// when the bump-* adapters are intentionally disabled — the CHANGELOG
+// sits in every detector's allowed set, so without this guard a bump PR
+// is swallowed by whichever non-bump detector runs first. With the
+// guard, a CHANGELOG-only change is matched solely by the bump-*
+// detectors, so disabling those adapters reliably keeps version bumps
+// out of trivial auto-merge. The CHANGELOG may still ACCOMPANY a docs or
+// update PR; it just can never be the sole trigger.
+func isChangelogOnly(files []string) bool {
+	if len(files) == 0 {
+		return false
+	}
+	for _, f := range files {
+		if !strings.EqualFold(filepath.Base(f), changelogFile) {
+			return false
+		}
+	}
+	return true
+}
 
 // allDetectors contains all built-in trivial PR detectors keyed by name.
 //

--- a/internal/infrastructure/repositories/trivial/registry_test.go
+++ b/internal/infrastructure/repositories/trivial/registry_test.go
@@ -73,17 +73,101 @@ func TestDetectorRegistry(t *testing.T) {
 		assert.Equal(t, "approve", result.Verdict)
 	})
 
-	t.Run("should return first matching detector", func(t *testing.T) {
-		// given
-		registry := trivial.NewDetectorRegistry([]string{"update-go", "docs-only"})
-		dctx := repositories.DetectionContext{Files: []string{"CHANGELOG.md"}} // matches both update-go and docs-only
+	t.Run("should return the first matching detector when several match", func(t *testing.T) {
+		// given -- a Node version bump (package.json + CHANGELOG.md) matches both
+		// bump-node and update-node; the first registered detector wins.
+		registry := trivial.NewDetectorRegistry([]string{"bump-node", "update-node"})
+		dctx := repositories.DetectionContext{Files: []string{"package.json", "CHANGELOG.md"}}
 
 		// when
 		detector, _, found := registry.Detect(ctx, dctx)
 
 		// then
 		assert.True(t, found)
-		assert.Equal(t, "update-go", detector.Name()) // update-go registered first
+		assert.Equal(t, "bump-node", detector.Name()) // bump-node registered first
+	})
+
+	t.Run("should not detect a CHANGELOG-only change via docs-only (it is a version bump)", func(t *testing.T) {
+		// given
+		registry := trivial.NewDetectorRegistry([]string{"docs-only"})
+		dctx := repositories.DetectionContext{Files: []string{"CHANGELOG.md"}}
+
+		// when
+		_, _, found := registry.Detect(ctx, dctx)
+
+		// then
+		assert.False(t, found)
+	})
+
+	t.Run("should not detect a CHANGELOG-only change via update-go (it is a version bump)", func(t *testing.T) {
+		// given
+		registry := trivial.NewDetectorRegistry([]string{"update-go"})
+		dctx := repositories.DetectionContext{Files: []string{"CHANGELOG.md"}}
+
+		// when
+		_, _, found := registry.Detect(ctx, dctx)
+
+		// then
+		assert.False(t, found)
+	})
+
+	t.Run("should not auto-approve a CHANGELOG-only bump when only docs/update adapters are enabled", func(t *testing.T) {
+		// given -- the bump-* adapters are intentionally disabled, leaving only
+		// docs-only and the update-* family; a CHANGELOG-only version bump must
+		// NOT slip through any of them.
+		registry := trivial.NewDetectorRegistry(
+			[]string{"docs-only", "update-go", "update-node", "update-python"},
+		)
+		dctx := repositories.DetectionContext{Files: []string{"CHANGELOG.md"}}
+
+		// when
+		_, _, found := registry.Detect(ctx, dctx)
+
+		// then
+		assert.False(t, found)
+	})
+
+	t.Run("should still claim a CHANGELOG-only change with bump-go when that adapter is enabled", func(t *testing.T) {
+		// given -- with a bump adapter enabled, the CHANGELOG-only bump is claimed
+		// by it (not by docs-only / update-go, which decline it).
+		registry := trivial.NewDetectorRegistry([]string{"docs-only", "update-go", "bump-go"})
+		dctx := repositories.DetectionContext{Files: []string{"CHANGELOG.md"}}
+
+		// when
+		detector, result, found := registry.Detect(ctx, dctx)
+
+		// then
+		assert.True(t, found)
+		assert.Equal(t, "bump-go", detector.Name())
+		assert.Equal(t, "approve", result.Verdict)
+	})
+
+	t.Run("should still detect docs-only when a real doc accompanies the CHANGELOG", func(t *testing.T) {
+		// given
+		registry := trivial.NewDetectorRegistry([]string{"docs-only"})
+		dctx := repositories.DetectionContext{Files: []string{"README.md", "CHANGELOG.md"}}
+
+		// when
+		detector, result, found := registry.Detect(ctx, dctx)
+
+		// then
+		assert.True(t, found)
+		assert.Equal(t, "docs-only", detector.Name())
+		assert.Equal(t, "approve", result.Verdict)
+	})
+
+	t.Run("should still detect update-go when a manifest accompanies the CHANGELOG", func(t *testing.T) {
+		// given
+		registry := trivial.NewDetectorRegistry([]string{"update-go"})
+		dctx := repositories.DetectionContext{Files: []string{"go.mod", "CHANGELOG.md"}}
+
+		// when
+		detector, result, found := registry.Detect(ctx, dctx)
+
+		// then
+		assert.True(t, found)
+		assert.Equal(t, "update-go", detector.Name())
+		assert.Equal(t, "approve", result.Verdict)
 	})
 
 	t.Run("should not detect anything with empty file list", func(t *testing.T) {

--- a/internal/infrastructure/repositories/trivial/update_go_detector.go
+++ b/internal/infrastructure/repositories/trivial/update_go_detector.go
@@ -33,6 +33,12 @@ func (d *UpdateGoDetector) Detect(_ context.Context, dctx repositories.Detection
 			return repositories.DetectionResult{}
 		}
 	}
+	// A CHANGELOG-only change is a version bump, not a dependency update —
+	// it must carry an actual manifest/lockfile change to count here. See
+	// isChangelogOnly.
+	if isChangelogOnly(dctx.Files) {
+		return repositories.DetectionResult{}
+	}
 	return repositories.DetectionResult{
 		Detected: true,
 		Verdict:  verdictApprove,

--- a/internal/infrastructure/repositories/trivial/update_node_detector.go
+++ b/internal/infrastructure/repositories/trivial/update_node_detector.go
@@ -38,6 +38,12 @@ func (d *UpdateNodeDetector) Detect(
 			return repositories.DetectionResult{}
 		}
 	}
+	// A CHANGELOG-only change is a version bump, not a dependency update —
+	// it must carry an actual manifest/lockfile change to count here. See
+	// isChangelogOnly.
+	if isChangelogOnly(dctx.Files) {
+		return repositories.DetectionResult{}
+	}
 	return repositories.DetectionResult{
 		Detected: true,
 		Verdict:  verdictApprove,

--- a/internal/infrastructure/repositories/trivial/update_python_detector.go
+++ b/internal/infrastructure/repositories/trivial/update_python_detector.go
@@ -38,6 +38,12 @@ func (d *UpdatePythonDetector) Detect(
 		}
 		return repositories.DetectionResult{}
 	}
+	// A CHANGELOG-only change is a version bump, not a dependency update —
+	// it must carry an actual manifest/lockfile change to count here. See
+	// isChangelogOnly.
+	if isChangelogOnly(dctx.Files) {
+		return repositories.DetectionResult{}
+	}
 	return repositories.DetectionResult{
 		Detected: true,
 		Verdict:  verdictApprove,


### PR DESCRIPTION
## Problem

The trivial-PR detectors classify a PR by its changed files. `CHANGELOG.md` sits in the allowed set of **every** category:

- `docs-only` matches any all-`.md` PR — and `CHANGELOG.md` is `.md`,
- `update-go` / `update-node` / `update-python` each include `CHANGELOG.md` in their allowed set and only check "all files allowed,"
- `bump-go` / `bump-node` / `bump-python` are the detectors that are *supposed* to claim it (a Go bump is literally `CHANGELOG.md`-only).

The registry returns the **first** matching detector. So a version-bump PR (which, for a Go project, touches only `CHANGELOG.md`) is claimed by whichever non-bump detector happens to run first — typically `docs-only` or `update-*`. **Consequence:** removing the `bump-*` adapters from the enabled list does *not* stop version bumps from being auto-approved (and, where auto-merge is enabled, auto-merged) — they silently fall through to `docs-only`/`update-*`.

## Fix

A change that touches **only** the CHANGELOG is the signature of a version bump / release ceremony and must be claimed **exclusively** by the `bump-*` detectors.

- Added a shared `isChangelogOnly(files)` guard in `registry.go`.
- `docs-only` and all three `update-*` detectors now decline a CHANGELOG-only change.
- The CHANGELOG may still **accompany** a genuine docs PR (`README.md` + `CHANGELOG.md`) or a dependency update (`go.mod` + `CHANGELOG.md`) — it just can't be the sole trigger.
- `bump-*` behaviour is unchanged: it still claims CHANGELOG-only PRs (validated against `.autobump.yaml` when present).

Net effect: disabling the `bump-*` adapters now reliably keeps version bumps out of trivial auto-approval, and the gate stays a strict AND of *(an enabled adapter matches)* ∧ *(author allowlist)* ∧ *(auto-merge enabled)*.

## Tests

`registry_test.go` gains coverage for:
- CHANGELOG-only is **not** detected by `docs-only` or `update-*`,
- the full scenario — `docs-only,update-go,update-node,update-python` enabled, `bump-*` disabled, CHANGELOG-only PR → **no match**,
- `bump-go` still claims a CHANGELOG-only PR when enabled,
- `docs-only`/`update-go` still match when a real doc/manifest accompanies the CHANGELOG.

`go build ./...`, `go test -tags unit ./...`, and `make lint` are all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)