### PR TITLE
fix(webhooks): skip self-authored comments to break the re-review loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - changed the Go module dependencies to their latest versions
 - changed the Go module dependencies to their latest versions
 
+### Fixed
+
+- fixed an infinite re-review loop where a comment webhook for the bot's own `@code-guru` annotation re-triggered a review; the GitHub and Azure DevOps mention handlers now skip comments authored by the bot itself — matched against the configured `bot_identities` / `CODE_GURU_BOT_IDENTITIES` or the built-in `code-guru` / `code-guru[bot]` / `code-guru@<tenant>` shapes via `support.IsBotAuthor` — so an oversized diff that can never pass review no longer floods the pull request with repeated "review failed" comments
+
 ## [1.8.3] - 2026-06-19
 
 ### Changed

--- a/internal/infrastructure/controllers/webhooks/azuredevops.go
+++ b/internal/infrastructure/controllers/webhooks/azuredevops.go
@@ -437,6 +437,21 @@ func (d *Dispatcher) handleADOComment(w http.ResponseWriter, _ *http.Request, bo
 		return
 	}
 
+	// A mention in a comment the bot itself authored (e.g. the
+	// "mention `@code-guru` ... to try again" line in its own "review
+	// failed" annotation) must NOT trigger a re-review. ADO fires a
+	// comment webhook for the bot's own posts too, so acting on them
+	// spins an infinite review->fail->annotate->webhook loop that floods
+	// the PR — observed on an oversized diff that could never pass review.
+	if commenter := adoIdentityName(event.Resource.Comment.Author); support.IsBotAuthor(d.settings.BotIdentities...)(commenter) {
+		logger.Debugf(
+			"ADO webhook: comment on PR #%d is authored by the bot itself (%s); skipping self-triggered re-review",
+			event.Resource.PullRequest.PullRequestID, commenter,
+		)
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
 	pr := event.Resource.PullRequest
 	org := extractADOOrganization(pr.Repository.RemoteURL)
 	if !d.allowedOrganization(org) || !d.allowedProject(pr.Repository.Project.Name) {

--- a/internal/infrastructure/controllers/webhooks/azuredevops_test.go
+++ b/internal/infrastructure/controllers/webhooks/azuredevops_test.go
@@ -22,8 +22,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/rios0rios0/codeguru/internal/domain/entities"
-	infraRepos "github.com/rios0rios0/codeguru/internal/infrastructure/repositories"
 	"github.com/rios0rios0/codeguru/internal/infrastructure/controllers/webhooks"
+	infraRepos "github.com/rios0rios0/codeguru/internal/infrastructure/repositories"
 	doubles "github.com/rios0rios0/codeguru/test/infrastructure/doubles/repositories"
 )
 
@@ -904,5 +904,28 @@ func TestHandleAzureDevOpsCommentMention(t *testing.T) {
 		// then
 		assert.Equal(t, http.StatusForbidden, w.Code)
 		assert.Empty(t, sub.Jobs())
+	})
+
+	t.Run("should respond 204 and not enqueue when the comment is authored by the bot itself", func(t *testing.T) {
+		t.Parallel()
+
+		// given: the bot's own "review failed" annotation carries a
+		// "mention `@code-guru` ... to try again" line. ADO fires a comment
+		// webhook for it; acting on it would loop forever. The payload's
+		// author (felipe@example) is pinned as a configured bot identity.
+		settings := defaultADOSettings()
+		settings.BotIdentities = []string{"felipe@example"}
+		body := adoCommentEventPayload("@code-guru re-review")
+		d, sub := newDispatcherWithSettings(t, settings)
+		req := httptest.NewRequest(http.MethodPost, "/webhooks/azuredevops", bytes.NewBufferString(body))
+		req.Header.Set("Authorization", adoBasicAuth(adoSecret))
+		w := httptest.NewRecorder()
+
+		// when
+		d.HandleAzureDevOps(w, req)
+
+		// then
+		assert.Equal(t, http.StatusNoContent, w.Code)
+		assert.Empty(t, sub.Jobs(), "the bot must not re-review its own comment")
 	})
 }

--- a/internal/infrastructure/controllers/webhooks/github.go
+++ b/internal/infrastructure/controllers/webhooks/github.go
@@ -253,6 +253,16 @@ func (d *Dispatcher) handleGitHubIssueComment(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	// Skip comments the bot itself authored: its own annotations carry an
+	// "@code-guru ... to try again" line, and re-reviewing on that would
+	// loop review->fail->annotate->webhook forever (see the ADO handler).
+	if commenter := event.Comment.User.Login; support.IsBotAuthor(d.settings.BotIdentities...)(commenter) {
+		logger.Debugf("GitHub webhook: issue_comment on PR #%d is authored by the bot itself (%s); skipping self-triggered re-review",
+			event.Issue.Number, commenter)
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
 	owner, repoName, splitErr := splitFullName(event.Repository.FullName)
 	if splitErr != nil {
 		writeError(w, http.StatusBadRequest, "invalid repository.full_name")

--- a/internal/infrastructure/controllers/webhooks/github_test.go
+++ b/internal/infrastructure/controllers/webhooks/github_test.go
@@ -442,6 +442,28 @@ func TestHandleGitHubIssueCommentMention(t *testing.T) {
 		assert.Equal(t, 12, jobs[0].PR.ID)
 	})
 
+	t.Run("should respond 204 and not enqueue when the comment is authored by the bot itself", func(t *testing.T) {
+		t.Parallel()
+
+		// given: re-reviewing the bot's own "@code-guru ... to try again"
+		// annotation would loop review->fail->annotate->webhook forever.
+		// "felipe" is the payload's comment author; pin it as a configured
+		// bot identity so the self-author guard recognises it.
+		settings := defaultGitHubSettings()
+		settings.BotIdentities = []string{"felipe"}
+		body := ghIssueCommentPayload("@code-guru re-review")
+		d, sub := newDispatcherWithGitHubTokenizer(t, settings)
+		req := githubRequest(t, ghSecret, body, "issue_comment")
+		w := httptest.NewRecorder()
+
+		// when
+		d.HandleGitHub(w, req)
+
+		// then
+		assert.Equal(t, http.StatusNoContent, w.Code)
+		assert.Empty(t, sub.Jobs(), "the bot must not re-review its own comment")
+	})
+
 	t.Run("should respond 204 when the comment has no @code-guru mention", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
A comment webhook fired for the bot's own "review failed" annotation (which contains a "mention `@code-guru` ... to try again" line) re-triggered a mention re-review. On an oversized diff that can never pass review, this spun an infinite review->fail->annotate->webhook loop that flooded the PR with thousands of "review failed" comments.

The GitHub and Azure DevOps mention handlers now skip comments whose author matches a configured bot identity (CODE_GURU_BOT_IDENTITIES) or the built-in code-guru[bot] shape, before enqueuing the re-review.

DS-6563

## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?
- [x] Did you run all the code checks? (`go test`)
- [x] Are the tests passing?
