### PR TITLE
fix(security): resolve Semgrep incorrect-default-permission on auth config dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 - changed the Go module dependencies to their latest versions
 
+### Security
+
+- resolved the Semgrep `incorrect-default-permission` CI failure on the auth config directory by documenting why owner-only `0o700` is the least-privilege mode for a directory (a directory needs the owner execute bit, so the rule's `0o600` file threshold would strip required access)
+
 ## [1.9.1] - 2026-07-14
 
 ### Changed

--- a/internal/infrastructure/repositories/auth/filesystem_token_repository.go
+++ b/internal/infrastructure/repositories/auth/filesystem_token_repository.go
@@ -29,6 +29,9 @@ func NewFilesystemTokenRepository() (*FilesystemTokenRepository, error) {
 
 // SaveToken persists an OAuth token to the filesystem.
 func (r *FilesystemTokenRepository) SaveToken(token entities.AuthToken) error {
+	// The config dir holds the auth token (written 0o600 below), so it stays owner-only; a
+	// directory needs the owner execute bit, making 0o700 (not 0o600) the least-privilege mode.
+	// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
 	if err := os.MkdirAll(r.configDir, 0o700); err != nil {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}


### PR DESCRIPTION
## Problem

CI `sast:semgrep` fails on `main` with one blocking finding:

```
go.lang.correctness.permissions.file_permission.incorrect-default-permission
internal/infrastructure/repositories/auth/filesystem_token_repository.go:32
```

The rule (a gosec/G301-G302 port, CWE-276) flags `os.Chmod/Mkdir/OpenFile/MkdirAll/ioutil.WriteFile` whenever the mode is **strictly greater than `0o600`**.

## Root cause

The flagged call already uses the tightest viable mode:

```go
os.MkdirAll(r.configDir, 0o700)   // config dir for ~/.config/code-guru/auth.json
```

A **directory** must keep the owner *execute* (search) bit or the process can neither create nor read files inside it (`0o600` dir ⇒ `permission denied`). So `0o700` is already the least-privilege mode for a directory — the rule's `0o600` threshold is file-oriented and does not apply here. The token file itself is already written `0o600` (owner-only), so the security posture is correct.

This is therefore a **false positive**, not a loosely-permissioned path: there is no mode `≤ 0o600` that keeps the directory usable.

## Fix

- Added a **rule-scoped** `// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission` with a rationale comment explaining why `0o700` is least-privilege for a directory. The rule stays active everywhere else in the repo (e.g. it would still catch a genuinely loose `os.OpenFile`/`ioutil.WriteFile`).
- No behaviour change; the mode is unchanged (`0o700`), the token file stays `0o600`.
- `CHANGELOG.md` updated under `[Unreleased] > Security`.

Verified locally: `golangci-lint` (pipelines config) → 0 issues; `go build ./...` OK; the `nosemgrep` directive suppresses the finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)