### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -124,10 +124,12 @@ Available subcommands:
 | `review <url>` | Review a single PR by URL (GitHub or Azure DevOps)       |
 | `review-all`   | Batch-review all open PRs across configured providers    |
 | `discover`     | Discover repos and list open PRs without posting reviews |
-| `auth`         | OAuth login/logout/status (login flow WIP)               |
 | `serve`        | Start webhook server for automatic PR review             |
+| `health`       | Probe a running `serve` listener (Docker healthcheck client) |
 | `self-update`  | Update the CLI binary to the latest version              |
 | `version`      | Print the current CLI version                            |
+
+The `auth` controller and its filesystem token store exist in the tree but are **not** DI-registered (login is a TODO), so `auth` is not an available subcommand.
 
 Common flags (all commands):
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `.github/copilot-instructions.md` to fix the CLI subcommands table, which listed the unwired `auth` stub as an available command and omitted the actual `health` probe command
+
 ## [1.14.1] - 2026-07-30
 
 ### Changed


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.