### PR TITLE
chore(deps): bumped `langforge` to `v1.0.0` and mapped the new Dart language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,15 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added Dart to the languages the reviewer recognises: a pull request touching `.dart` files now selects the `dart` rule category and labels those hunks as Dart in the prompt, where before they classified as unknown and contributed no language rules. Operators who keep a `dart.md` in their `rules.path` get it enforced automatically; those who do not are unaffected, since an unmatched category simply loads nothing
+- added `README.md` documentation of the language rule categories the classifier can produce, so an operator can tell which filename a language-specific rule file needs
+
 ### Changed
 
 - changed the Go version to `1.26.6` and updated all module dependencies
+- changed `langforge` from `v0.6.11` to `v1.0.0`. The major release removed the nine per-ecosystem `Provider` structs (replaced by `repositories.CompositeProvider`) and the `javagradle`/`javamaven` `RuntimeManager` types (replaced by a shared `java.RuntimeManager`); Code Guru names none of those symbols, consuming only `pkg/domain/entities` for extension-based classification, so the breaking changes pass it by
 
 ## [1.15.3] - 2026-08-13
 

--- a/README.md
+++ b/README.md
@@ -501,7 +501,20 @@ Use `gofmt` for formatting...
 
 Universal categories (always included): `architecture`, `ci-cd`, `code-style`, `design-patterns`, `documentation`, `git-flow`, `security`, `testing`.
 
-Language categories are selected from the extensions of the files the PR touches: `golang`, `javascript`, `python`, `java`, `ruby`, `dart`, `csharp`, `terraform`, `yaml`, `ci-cd`, `dockerfile`. A category with no matching file in the rules directory simply contributes nothing — only the universal rules and the matched languages are sent to the model.
+Language categories are selected purely from the **extensions** of the files the PR touches — extensionless names such as `Dockerfile` are not classified:
+
+| Category     | Extensions                                    |
+|--------------|-----------------------------------------------|
+| `golang`     | `.go`                                         |
+| `javascript` | `.js`, `.ts`, `.jsx`, `.tsx`, `.mjs`, `.cjs`  |
+| `python`     | `.py`                                         |
+| `dart`       | `.dart`                                       |
+| `java`       | `.java`                                       |
+| `csharp`     | `.cs`                                         |
+| `terraform`  | `.tf`, `.hcl`                                 |
+| `yaml`       | `.yaml`, `.yml`                               |
+
+A category with no matching `.md` file in the rules directory simply contributes nothing — only the universal rules and the matched languages are sent to the model.
 
 ### Project Guidelines (CLAUDE.md)
 

--- a/README.md
+++ b/README.md
@@ -501,6 +501,8 @@ Use `gofmt` for formatting...
 
 Universal categories (always included): `architecture`, `ci-cd`, `code-style`, `design-patterns`, `documentation`, `git-flow`, `security`, `testing`.
 
+Language categories are selected from the extensions of the files the PR touches: `golang`, `javascript`, `python`, `java`, `ruby`, `dart`, `csharp`, `terraform`, `yaml`, `ci-cd`, `dockerfile`. A category with no matching file in the rules directory simply contributes nothing — only the universal rules and the matched languages are sent to the model.
+
 ### Project Guidelines (CLAUDE.md)
 
 On top of the operator-configured rules, Code Guru reads the **reviewed repository's own root `CLAUDE.md`** — the file projects use to document conventions for AI tooling — and forwards it to the AI as project-specific review context. This works on every supported provider (GitHub and Azure DevOps) through the same file-access API the trivial detectors use, and it means the review honours conventions the generic ruleset cannot know about (naming, layering, testing patterns, intentional trade-offs).

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require github.com/rios0rios0/cliforge v0.3.14
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/rios0rios0/gitforge v1.0.1-0.20260723193418-4150608363f0
-	github.com/rios0rios0/langforge v0.6.11
+	github.com/rios0rios0/langforge v1.0.0
 	github.com/rios0rios0/testkit v0.2.6
 	github.com/sashabaranov/go-openai v1.42.0
 	github.com/sirupsen/logrus v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/rios0rios0/cliforge v0.3.14 h1:g3hSNyhLFgemWWgO+zzCQvbBprEiIuN2ARhV3j
 github.com/rios0rios0/cliforge v0.3.14/go.mod h1:6+3AwCsoJlSDaw7pu2Qe8S5Jw/059ZBMyZuQVcyFps8=
 github.com/rios0rios0/gitforge v1.0.1-0.20260723193418-4150608363f0 h1:N9cJT9CbK1+kkIdkXeQx2jYju/wFLiT1+bfJb0l61ww=
 github.com/rios0rios0/gitforge v1.0.1-0.20260723193418-4150608363f0/go.mod h1:fuwZbZ2YUVzUXy0knyD/wU9YjgZpef2HpCkOVJsSSgg=
-github.com/rios0rios0/langforge v0.6.11 h1:40Hs4VsOCx3vbl9WtOay5LfnDrG8d3VJ+Ivty8BHBnM=
-github.com/rios0rios0/langforge v0.6.11/go.mod h1:BcPZELX3TWdrPI7MzpevpNwXfwRJAsgrEZ+J5BLTq+s=
+github.com/rios0rios0/langforge v1.0.0 h1:J+5NdV30dDq1LW9jdDQKCeoAuEuUreocosvWbnbu8qQ=
+github.com/rios0rios0/langforge v1.0.0/go.mod h1:TabMEVXALv2Vvj4Er/4u9mf2SAmzv0xjkB1TxFA7SPo=
 github.com/rios0rios0/testkit v0.2.6 h1:JtHkUwxrO3Uog5xYhZTVmdbrjyHEz36Vre3a2SR4yY8=
 github.com/rios0rios0/testkit v0.2.6/go.mod h1:dsQ2xX7nMAOkquTgakoA2/Z2sMBuBkCSEyLZMwpXU/Q=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/internal/support/file_classifier.go
+++ b/internal/support/file_classifier.go
@@ -17,6 +17,7 @@ var languageToRuleCategory = map[entities.Language]string{
 	entities.LanguageJavaGradle: langJava,
 	entities.LanguageJavaMaven:  langJava,
 	entities.LanguageRuby:       "ruby",
+	entities.LanguageDart:       "dart",
 	entities.LanguageCSharp:     "csharp",
 	entities.LanguageTerraform:  "terraform",
 	entities.LanguageYAML:       "yaml",

--- a/internal/support/file_classifier_test.go
+++ b/internal/support/file_classifier_test.go
@@ -46,6 +46,17 @@ func TestClassifyFile(t *testing.T) {
 		assert.Equal(t, "python", result)
 	})
 
+	t.Run("should classify Dart files", func(t *testing.T) {
+		// given
+		path := "lib/main.dart"
+
+		// when
+		result := support.ClassifyFile(path)
+
+		// then
+		assert.Equal(t, "dart", result)
+	})
+
 	t.Run("should classify YAML files", func(t *testing.T) {
 		// given
 		path := "config.yaml"


### PR DESCRIPTION
## Why

`rios0rios0/langforge` released **`v1.0.0`**. Code Guru pinned `v0.6.11`, so this bump crosses a **major** boundary.

## The breaking changes do not reach this repository

`v1.0.0` ships two documented breaking changes:

1. the nine per-ecosystem `Provider` structs were removed, replaced by `repositories.CompositeProvider`;
2. `javagradle.RuntimeManager` and `javamaven.RuntimeManager` were removed in favour of a shared `java.RuntimeManager`.

Code Guru names **none** of those symbols. Its entire `langforge` surface is one file — `internal/support/file_classifier.go` — which imports only `github.com/rios0rios0/langforge/pkg/domain/entities` and uses exactly three symbols from it: the `entities.Language` type, `entities.ClassifyFileByExtension`, and `entities.ClassifyFilesByExtension`. No provider, no runtime manager, no ecosystem package. `go build ./...` and `go vet ./...` are clean without a single source change on that front.

## `go.mod` moved by exactly one line

```diff
-	github.com/rios0rios0/langforge v0.6.11
+	github.com/rios0rios0/langforge v1.0.0
```

`go mod tidy` moved nothing else — `go.sum` carries only the two matching `langforge` lines. No transitive dependency rode along.

## What `.dart` classification actually changes here

`v1.0.0` adds `LanguageDart` and the `.dart` → `LanguageDart` extension mapping. That is a **real behaviour change for this repository**, not a no-op, and it needed one source change:

**The `exhaustive` linter fails without it.** `languageToRuleCategory` is a map keyed on the `entities.Language` enum, and the shared pipelines config runs `exhaustive` with `check: [switch, map]`. A new enum member the map does not list is a lint error:

```
internal/support/file_classifier.go:12:30: missing keys in map of key type entities.Language: entities.LanguageDart (exhaustive)
```

This is the same failure the repository already hit once, when a `langforge` upgrade introduced `LanguageRuby` (see `CHANGELOG.md`). `go build ./...` passing is therefore **not** sufficient evidence that this bump is inert — `make lint` is what catches it.

**Downstream effect of mapping it to `dart`.** `ClassifyFile`/`ClassifyFiles` feed two consumers, and `.dart` files behave differently in both now:

| Consumer | Before (`v0.6.11`) | After (`v1.0.0`) |
|---|---|---|
| `ReviewCommand.buildDiffs` → `FileDiff.Language` | `""`, rendered as `### File: lib/main.dart (text)` | `"dart"`, rendered as `### File: lib/main.dart (dart)` |
| `ReviewCommand` → `RulesRepository.LoadForLanguages` | contributed no category | contributes the `dart` category |

Both are safe, and the second is the user-visible gain:

- **Nothing breaks for operators without Dart rules.** `FilesystemRulesRepository` derives categories from the filenames present in `rules.path`; a category with no matching `.md` file simply matches nothing in the filter loop. The universal categories (`architecture`, `ci-cd`, `code-style`, `design-patterns`, `documentation`, `git-flow`, `security`, `testing`) load exactly as before, so a Dart PR is reviewed no worse than it was.
- **Operators who keep a `dart.md` now get it enforced**, where previously it could only be reached through a `paths:` frontmatter glob. Worth knowing: the pipelines repo shipped Dart/Flutter support recently, so a `dart.md` rule file is a plausible thing to have.
- The prompt's per-file language tag is an annotation on the header line only — the fence itself is always ` ```diff `, so no fenced block changes shape.

There is **no fixed set of languages** in this repository that a new one could fall outside of: `languageToRuleCategory` is the whole registry, rule categories are open-ended filenames, and no per-language branching exists anywhere else. So `dart` needed a mapping, not an exclusion.

Added a `should classify Dart files` case to `file_classifier_test.go` pinning `lib/main.dart` → `dart`.

## Documentation

`README.md`, `CLAUDE.md`, and `.github/copilot-instructions.md` were all checked: none enumerated the classifiable languages, so nothing went stale. But the new capability was undiscoverable — an operator had no way to learn that a Dart rule file must be named `dart.md` — so the README's Rules section now carries a category/extension table.

Writing that table surfaced a **pre-existing quirk worth knowing about** (not introduced here, and not fixed here): three entries in `languageToRuleCategory` are unreachable.

| Category | Mapped from | Reachable? |
|---|---|---|
| `ruby` | `LanguageRuby` | **No** — the extension table has no `.rb` |
| `ci-cd` | `LanguagePipeline` | **No** — nothing produces `LanguagePipeline` |
| `dockerfile` | `LanguageDockerfile` | **No** — `filepath.Ext("Dockerfile")` is `""`, so it classifies as unknown |

`ClassifyFileByExtension` is `filepath.Ext` plus a lookup table and nothing more — it has no special-filename handling. Those three entries exist only to satisfy `exhaustive` over the full `entities.Language` enum, so they must stay in the map, but they can never be selected. The README table therefore documents only the eight categories an operator can actually trigger: `golang`, `javascript`, `python`, `dart`, `java`, `csharp`, `terraform`, `yaml`. (`ci-cd` still loads on every review — as a *universal* category, which is a different mechanism.)

Worth a follow-up decision by a maintainer: `dockerfile` and `ci-cd` rule files are plausible things for an operator to write, and today they would silently never load except through a `paths:` frontmatter glob. That is out of scope for a dependency bump.

## Validation

| Gate | Result |
|---|---|
| `make lint` | 0 issues (79 linters) — failed before the `LanguageDart` map entry, clean after |
| `make test` | 867 tests, all passing |
| `make sast` | clean — CodeQL, Semgrep (0 findings / 122 rules), Trivy (0 findings), Hadolint, Gitleaks (both passes, no leaks) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
